### PR TITLE
Add more code coverage for rule parser

### DIFF
--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/ExpressionBuilderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/ExpressionBuilderTest.cs
@@ -25,6 +25,17 @@ public class ExpressionBuilderTest : IClassFixture<RuleParserFixture>
     }
 
     [Fact]
+    public void NoParameterTestFromCompilationResult()
+    {
+        var expression = RuleParserFixture.ResolveRuleParserEngine()
+                                                .ParseString("1 == 2")
+                                                .BuildExpression()
+                                                .Compile();
+
+        Assert.False(expression.Invoke());
+    }
+
+    [Fact]
     public void TwoParameterTest()
     {
         var tokens = RuleParserFixture.ResolveRuleParserEngine()
@@ -34,6 +45,23 @@ public class ExpressionBuilderTest : IClassFixture<RuleParserFixture>
         var expression = RuleParserExpressionBuilder.BuildExpression<Survey, Survey>(tokens, "Survey", "Size");
 
         Assert.True(expression.Compile().Invoke(new SurveyModelBuilder()
+                                                .WithSurgeryCount(24)
+                                                .Value,
+
+                                                new SurveyModelBuilder()
+                                                .WithSurgeryCount(12)
+                                                .Value));
+    }
+
+    [Fact]
+    public void TwoParameterTestWithCompilationResult()
+    {
+        var expression = RuleParserFixture.ResolveRuleParserEngine()
+                                            .ParseString("$Survey.SurgeryCount == 24 && $Size.SurgeryCount == 12")
+                                            .BuildExpression<Survey, Survey>("Survey", "Size")
+                                            .Compile();
+
+        Assert.True(expression.Invoke(new SurveyModelBuilder()
                                                 .WithSurgeryCount(24)
                                                 .Value,
 
@@ -63,4 +91,26 @@ public class ExpressionBuilderTest : IClassFixture<RuleParserFixture>
                                                 .WithSurgeryCount(15)
                                                 .Value));
     }
+
+    [Fact]
+    public void ThreeParameterTestWithCompilationResult()
+    {
+        var expression = RuleParserFixture.ResolveRuleParserEngine()
+                                            .ParseString("$Survey.SurgeryCount == 30 && $Size.SurgeryCount == 12 && $Color.SurgeryCount == 15")
+                                            .BuildExpression<Survey, Survey, Survey>("Survey", "Size", "Color")
+                                            .Compile();
+
+        Assert.True(expression.Invoke(new SurveyModelBuilder()
+                                                .WithSurgeryCount(30)
+                                                .Value,
+
+                                                new SurveyModelBuilder()
+                                                .WithSurgeryCount(12)
+                                                .Value,
+
+                                                new SurveyModelBuilder()
+                                                .WithSurgeryCount(15)
+                                                .Value));
+    }
+
 }


### PR DESCRIPTION
add more code coverage for rule parser. We need to cover the compilation from the result object when parsing a string.
The 2 and 3 parameter overloads were not covered.