### PR TITLE
Struct Span String Reader For Performance

### DIFF
--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/BitMaskBuilderPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/BitMaskBuilderPerfTest.cs
@@ -2,7 +2,7 @@
 using LibraryCore.Core.EnumUtilities;
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests;
 
 [SimpleJob]
 [MemoryDiagnoser]

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/ImmutableListBuilderPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/ImmutableListBuilderPerfTest.cs
@@ -2,7 +2,7 @@
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 using System.Collections.Immutable;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests;
 
 [SimpleJob]
 [MemoryDiagnoser]

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/RuleParser/RuleParserPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/RuleParser/RuleParserPerfTest.cs
@@ -6,7 +6,7 @@ using LibraryCore.Performance.Tests.TestHarnessProvider;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Immutable;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests.RuleParser;
 
 [SimpleJob]
 [MemoryDiagnoser]

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderFuncVsDoublePeekPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderFuncVsDoublePeekPerfTest.cs
@@ -1,7 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests;
 
 [SimpleJob]
 [MemoryDiagnoser]

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
@@ -3,13 +3,13 @@ using LibraryCore.Core.Readers;
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 using System.Text;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests;
 
 [SimpleJob]
 [MemoryDiagnoser]
 public class StringReaderVsSpanReadPerfTest : IPerformanceTest
 {
-    public string CommandName => "StringReaderVsSpanRead";
+    public string CommandName => "StringReaderVsSpan.GeneralTest";
     public string Description => "Read a string and determine if a string reader or a span slice if faster";
 
     [Params("1 == 1",
@@ -56,7 +56,7 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
         while (reader.Peek() != -1)
         {
             reader.Peek();
-            sb.Append((char)reader.Read());
+            sb.Append(reader.Read());
         }
 
         return sb.ToString();

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanScanForCharacterPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanScanForCharacterPerfTest.cs
@@ -31,8 +31,6 @@ public class StringReaderVsSpanScanForCharacterPerfTest : IPerformanceTest
         return sb.ToString();
     }
 
-
-
     [Benchmark]
     public string StructSpanStringReaderInLibrary()
     {

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanScanForCharacterPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanScanForCharacterPerfTest.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using LibraryCore.Core.Readers;
+using LibraryCore.Performance.Tests.TestHarnessProvider;
+using System.Text;
+
+namespace LibraryCore.Performance.Tests.PrefTests;
+
+[SimpleJob]
+[MemoryDiagnoser]
+public class StringReaderVsSpanScanForCharacterPerfTest : IPerformanceTest
+{
+    public string CommandName => "StringReaderVsSpan.ScanForCharacter";
+    public string Description => "Scan for a character in a string reader vs string span reader";
+
+    [Params("1 == 1 && 2 == 2",
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz && zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz && zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")]
+    public string CodeToParse { get; set; }
+
+    [Benchmark(Baseline = true)]
+    public string StringReader()
+    {
+        var sb = new StringBuilder();
+        using var reader = new StringReader(CodeToParse);
+
+        while (reader.Peek() != -1 && reader.Peek() != '&')
+        {
+            sb.Append((char)reader.Read());
+        }
+
+        return sb.ToString();
+    }
+
+
+
+    [Benchmark]
+    public string StructSpanStringReaderInLibrary()
+    {
+        var reader = new StringSpanReader(CodeToParse);
+
+        return reader.ReadUntilCharacter("&", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/TemplatePerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/TemplatePerfTest.cs
@@ -2,7 +2,7 @@
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 using System.Text;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests;
 
 [SimpleJob]
 [MemoryDiagnoser]

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/UnionTypePerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/UnionTypePerfTest.cs
@@ -2,7 +2,7 @@
 using LibraryCore.Core.DataTypes.Unions;
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 
-namespace LibraryCore.Performance.Tests.Tests;
+namespace LibraryCore.Performance.Tests.PrefTests;
 
 [SimpleJob]
 [MemoryDiagnoser]

--- a/PerformanceTests/LibraryCore.Performance.Tests/Tests/StringReaderVsSpanReadPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/Tests/StringReaderVsSpanReadPerfTest.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
+using LibraryCore.Core.Readers;
 using LibraryCore.Performance.Tests.TestHarnessProvider;
 using System.Text;
 
@@ -11,10 +12,8 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
     public string CommandName => "StringReaderVsSpanRead";
     public string Description => "Read a string and determine if a string reader or a span slice if faster";
 
-
     [Params("1 == 1",
             "'one' =asdf asdf asdffasd fasdf asdasdf asdfasasdfasddfasdfasd= 'one'",
-            "1 == 1 && 2 == 2 && true == true asdfasdfasd assd fasd fasdf asdf asdf asdf asdf asdf asdfasdfasddf asdf asdf asdf",
             "1 == 1 && 2 == 2 && true == true asdfasdfasd assd fasd fasdf asdf asdf asdf asdf asdf asdfasdfasddf asdf asdf asdf == true asdfasdfasd assd fasd fasdf asdf asdf asdf asdf asdf asdfasdfasddf asdf asdf asdf")]
     public string CodeToParse { get; set; }
 
@@ -26,6 +25,7 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
 
         while (reader.Peek() != -1)
         {
+            reader.Peek();
             sb.Append((char)reader.Read());
         }
 
@@ -40,6 +40,7 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
 
         while (reader.Peek() != -1)
         {
+            reader.Peek();
             sb.Append((char)reader.Read());
         }
 
@@ -54,6 +55,7 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
 
         while (reader.Peek() != -1)
         {
+            reader.Peek();
             sb.Append((char)reader.Read());
         }
 
@@ -68,7 +70,23 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
 
         while (reader.Peek() != -1)
         {
+            reader.Peek();
             sb.Append((char)reader.Read());
+        }
+
+        return sb.ToString();
+    }
+
+    [Benchmark]
+    public string StructSpanStringReaderInLibrary()
+    {
+        var sb = new StringBuilder();
+        var reader = new StringSpanReader(CodeToParse);
+
+        while (reader.HasMoreCharacters())
+        {
+            reader.Peek();
+            sb.Append(reader.Read());
         }
 
         return sb.ToString();
@@ -134,10 +152,6 @@ public ref struct StructSpanStringReader
 
     public int Read()
     {
-        var text = StringToRead[Index];
-
-        Index++;
-
-        return text;
+        return StringToRead[Index++];
     }
 }

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -1,0 +1,51 @@
+﻿namespace LibraryCore.Core.Readers;
+
+/// <summary>
+/// This a strict ensure you pass a ref value into any methods otherwise, the Index get's copied resulting in weird issues
+/// </summary>
+public ref struct StringSpanReader
+{
+    public StringSpanReader(string stringToParse)
+    {
+        StringToParse = stringToParse;
+        Index = 0;
+    }
+
+    private ReadOnlySpan<char> StringToParse { get; }
+    private int Index { get; set; }
+
+    public bool HasMoreCharacters() => Index < StringToParse.Length;
+    public char? Peek() => HasMoreCharacters() ? StringToParse[Index] : null;
+    public char? Read() => HasMoreCharacters() ? StringToParse[Index++] : null;
+
+    public string? Peek(int numberOfCharacters)
+    {
+        if (!HasMoreCharacters())
+        {
+            return null;
+        }
+
+        return new string(DontHaveEnoughCharactersLeft(numberOfCharacters) ?
+                                    StringToParse[Index..] :
+                                    StringToParse.Slice(Index, numberOfCharacters));
+    }
+
+    public string? Read(int numberOfCharacters)
+    {
+        if (!HasMoreCharacters())
+        {
+            return null;
+        }
+
+        var stringToReturn = new string(DontHaveEnoughCharactersLeft(numberOfCharacters) ?
+                                    StringToParse[Index..] :
+                                    StringToParse.Slice(Index, numberOfCharacters));
+
+        //need to fast forward the index. This way its sitting at the character we are up to after the read x amount of characters
+        Index += numberOfCharacters;
+
+        return stringToReturn;
+    }
+
+    private bool DontHaveEnoughCharactersLeft(int numberOfCharactersToScan) => (Index + numberOfCharactersToScan) > StringToParse.Length;
+}

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -47,4 +47,21 @@ public ref struct StringSpanReader
                                     StringToParse[Index..] :
                                     StringToParse.Slice(Index, numberOfCharactersToScan));
     }
+
+    public string? ReadUntilCharacter(string characterToLookFor, StringComparison stringComparison)
+    {
+        var tryToFindIndex = StringToParse.IndexOf(characterToLookFor, stringComparison);
+
+        if(tryToFindIndex == -1)
+        {
+            return null;
+        }
+
+        var tempResult = new string(StringToParse.Slice(Index, tryToFindIndex));
+        
+        //fast forward the index
+        Index = tryToFindIndex;
+
+        return tempResult;
+    }
 }

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -4,6 +4,7 @@
 /// This a strict ensure you pass a ref value into any methods otherwise, the Index get's copied resulting in weird issues.
 /// This is faster by a string reader by 2x.
 /// </summary>
+/// <remarks>See StringReaderVsSpanReadPerfTest for the performance test</remarks>
 public ref struct StringSpanReader
 {
     public StringSpanReader(string stringToParse)
@@ -16,8 +17,8 @@ public ref struct StringSpanReader
     private int Index { get; set; }
 
     public bool HasMoreCharacters() => Index < StringToParse.Length;
-    public char? Peek() => HasMoreCharacters() ? StringToParse[Index] : null;
-    public char? Read() => HasMoreCharacters() ? StringToParse[Index++] : null;
+    public char Peek() => StringToParse[Index];
+    public char Read() => StringToParse[Index++];
 
     public string? Peek(int numberOfCharacters) => PeekOrReadMultipleCharacters(numberOfCharacters);
 

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -1,7 +1,8 @@
 ﻿namespace LibraryCore.Core.Readers;
 
 /// <summary>
-/// This a strict ensure you pass a ref value into any methods otherwise, the Index get's copied resulting in weird issues
+/// This a strict ensure you pass a ref value into any methods otherwise, the Index get's copied resulting in weird issues.
+/// This is faster by a string reader by 2x.
 /// </summary>
 public ref struct StringSpanReader
 {

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -18,34 +18,31 @@ public ref struct StringSpanReader
     public char? Peek() => HasMoreCharacters() ? StringToParse[Index] : null;
     public char? Read() => HasMoreCharacters() ? StringToParse[Index++] : null;
 
-    public string? Peek(int numberOfCharacters)
-    {
-        if (!HasMoreCharacters())
-        {
-            return null;
-        }
-
-        return new string(DontHaveEnoughCharactersLeft(numberOfCharacters) ?
-                                    StringToParse[Index..] :
-                                    StringToParse.Slice(Index, numberOfCharacters));
-    }
+    public string? Peek(int numberOfCharacters) => PeekOrReadMultipleCharacters(numberOfCharacters);
 
     public string? Read(int numberOfCharacters)
     {
+        var readCharacters = PeekOrReadMultipleCharacters(numberOfCharacters);
+
+        //did we have any characters read...if so then it was successful and we need to fast forward
+        if (readCharacters != null)
+        {
+            //need to fast forward the index. This way its sitting at the character we are up to after the read x amount of characters
+            Index += numberOfCharacters;
+        }
+
+        return readCharacters;
+    }
+
+    private string? PeekOrReadMultipleCharacters(int numberOfCharactersToScan)
+    {
         if (!HasMoreCharacters())
         {
             return null;
         }
 
-        var stringToReturn = new string(DontHaveEnoughCharactersLeft(numberOfCharacters) ?
+        return new string((Index + numberOfCharactersToScan) > StringToParse.Length ?
                                     StringToParse[Index..] :
-                                    StringToParse.Slice(Index, numberOfCharacters));
-
-        //need to fast forward the index. This way its sitting at the character we are up to after the read x amount of characters
-        Index += numberOfCharacters;
-
-        return stringToReturn;
+                                    StringToParse.Slice(Index, numberOfCharactersToScan));
     }
-
-    private bool DontHaveEnoughCharactersLeft(int numberOfCharactersToScan) => (Index + numberOfCharactersToScan) > StringToParse.Length;
 }

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -84,4 +84,23 @@ public class StringSpanReaderTest
 
     private static void PassStruct2(ref StringSpanReader reader) => Assert.Equal('c', reader.Read());
 
+    [Fact]
+    public void ReadUntilCharacterWhenFound()
+    {
+        var reader = new StringSpanReader("1 == 1 && 2 == 2");
+
+        var result = reader.ReadUntilCharacter("&&", StringComparison.OrdinalIgnoreCase);
+
+        Assert.Equal("1 == 1 ", result);
+        Assert.Equal('&', reader.Peek());
+    }
+
+    [Fact]
+    public void ReadUntilCharacterWhenNotFound()
+    {
+        var reader = new StringSpanReader("1 == 1 && 2 == 2");
+
+        Assert.Null(reader.ReadUntilCharacter("abc", StringComparison.OrdinalIgnoreCase));
+    }
+
 }

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -1,0 +1,89 @@
+﻿using LibraryCore.Core.Readers;
+
+namespace LibraryCore.Tests.Core.Readers;
+
+public class StringSpanReaderTest
+{
+    [Fact]
+    public void ReadCorrectly()
+    {
+        var reader = new StringSpanReader("Abc");
+
+        Assert.Equal('A', reader.Read());
+        Assert.Equal('b', reader.Read());
+        Assert.Equal('c', reader.Read());
+        Assert.Null(reader.Read());
+    }
+
+    [Fact]
+    public void HasMoreCharacters()
+    {
+        var reader = new StringSpanReader("bc");
+
+        Assert.True(reader.HasMoreCharacters());
+        reader.Read(); //should be at c
+        Assert.True(reader.HasMoreCharacters());
+        reader.Read(); //should be after c
+        Assert.False(reader.HasMoreCharacters());
+    }
+
+    [Fact]
+    public void PeekCorrectly()
+    {
+        var reader = new StringSpanReader("Abc");
+
+        Assert.Equal('A', reader.Peek());
+        Assert.Equal('A', reader.Read());
+        Assert.Equal('b', reader.Peek());
+        Assert.Equal('b', reader.Read());
+        Assert.Equal('c', reader.Peek());
+        Assert.Equal('c', reader.Read());
+        Assert.Null(reader.Peek());
+    }
+
+    [Fact]
+    public void PeekMultipleWhenNotEnoughCharacters() => Assert.Equal("Abc", new StringSpanReader("Abc").Peek(5));
+
+    [Fact]
+    public void PeekMultipleWhenAtTheEnd() => Assert.Null(new StringSpanReader("").Peek(1));
+
+    [Fact]
+    public void PeekMultipleWhenHaveCharactersLeftOverAfterPeek() => Assert.Equal("Ab", new StringSpanReader("Abcdef").Peek(2));
+
+    [Fact]
+    public void ReadMultipleWhenNotEnoughCharacters() => Assert.Equal("Abc", new StringSpanReader("Abc").Read(5));
+
+    [Fact]
+    public void ReadMultipleWhenAtTheEnd() => Assert.Null(new StringSpanReader("").Read(1));
+
+    [Fact]
+    public void ReadMultipleWhenHaveCharactersLeftOverAfterPeek()
+    {
+        var reader = new StringSpanReader("Abcdef");
+
+        Assert.Equal("Ab", reader.Read(2));
+
+        //now make sure we are up to c
+        Assert.Equal('c', reader.Peek());
+    }
+
+    [Fact]
+    public void EnsurePassingStructToMethodsWork()
+    {
+        var reader = new StringSpanReader("Abcdef");
+
+        Assert.Equal('A', reader.Read());
+
+        PassStruct1(ref reader);
+        Assert.Equal('d', reader.Read());
+    }
+
+    private static void PassStruct1(ref StringSpanReader reader)
+    {
+        Assert.Equal('b', reader.Read());
+        PassStruct2(ref reader);
+    }
+
+    private static void PassStruct2(ref StringSpanReader reader) => Assert.Equal('c', reader.Read());
+
+}

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -12,7 +12,6 @@ public class StringSpanReaderTest
         Assert.Equal('A', reader.Read());
         Assert.Equal('b', reader.Read());
         Assert.Equal('c', reader.Read());
-        Assert.Null(reader.Read());
     }
 
     [Fact]
@@ -38,7 +37,6 @@ public class StringSpanReaderTest
         Assert.Equal('b', reader.Read());
         Assert.Equal('c', reader.Peek());
         Assert.Equal('c', reader.Read());
-        Assert.Null(reader.Peek());
     }
 
     [Fact]


### PR DESCRIPTION
Struct span string reader for performance. This is 2x faster then a string reader for the purpose of parsing a string in a 'string reader' like fashion. Might use this for the parser but will determine that after a full perf test. For now, this is good for other uses.