### PR TITLE
String Struct Span Reader

### DIFF
--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
@@ -32,50 +32,50 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
         return sb.ToString();
     }
 
-    [Benchmark]
-    public string RawStringReader()
-    {
-        var sb = new StringBuilder();
-        var reader = new RawStringReader(CodeToParse);
+    //[Benchmark]
+    //public string RawStringReader()
+    //{
+    //    var sb = new StringBuilder();
+    //    var reader = new RawStringReader(CodeToParse);
 
-        while (reader.Peek() != -1)
-        {
-            reader.Peek();
-            sb.Append((char)reader.Read());
-        }
+    //    while (reader.Peek() != -1)
+    //    {
+    //        reader.Peek();
+    //        sb.Append((char)reader.Read());
+    //    }
 
-        return sb.ToString();
-    }
+    //    return sb.ToString();
+    //}
 
-    [Benchmark]
-    public string ClassSpanStringReader()
-    {
-        var sb = new StringBuilder();
-        var reader = new ClassSpanStringReader(CodeToParse);
+    //[Benchmark]
+    //public string ClassSpanStringReader()
+    //{
+    //    var sb = new StringBuilder();
+    //    var reader = new ClassSpanStringReader(CodeToParse);
 
-        while (reader.Peek() != -1)
-        {
-            reader.Peek();
-            sb.Append(reader.Read());
-        }
+    //    while (reader.Peek() != -1)
+    //    {
+    //        reader.Peek();
+    //        sb.Append(reader.Read());
+    //    }
 
-        return sb.ToString();
-    }
+    //    return sb.ToString();
+    //}
 
-    [Benchmark]
-    public string StructSpanStringReader()
-    {
-        var sb = new StringBuilder();
-        var reader = new StructSpanStringReader(CodeToParse);
+    //[Benchmark]
+    //public string StructSpanStringReader()
+    //{
+    //    var sb = new StringBuilder();
+    //    var reader = new StructSpanStringReader(CodeToParse);
 
-        while (reader.Peek() != -1)
-        {
-            reader.Peek();
-            sb.Append((char)reader.Read());
-        }
+    //    while (reader.Peek() != -1)
+    //    {
+    //        reader.Peek();
+    //        sb.Append((char)reader.Read());
+    //    }
 
-        return sb.ToString();
-    }
+    //    return sb.ToString();
+    //}
 
     [Benchmark]
     public string StructSpanStringReaderInLibrary()
@@ -83,7 +83,7 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
         var sb = new StringBuilder();
         var reader = new StringSpanReader(CodeToParse);
 
-        while (reader.HasMoreCharacters())
+        while (reader.HasMoreCharacters)
         {
             reader.Peek();
             sb.Append(reader.Read());

--- a/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PrefTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
@@ -32,50 +32,50 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
         return sb.ToString();
     }
 
-    //[Benchmark]
-    //public string RawStringReader()
-    //{
-    //    var sb = new StringBuilder();
-    //    var reader = new RawStringReader(CodeToParse);
+    [Benchmark]
+    public string RawStringReader()
+    {
+        var sb = new StringBuilder();
+        var reader = new RawStringReader(CodeToParse);
 
-    //    while (reader.Peek() != -1)
-    //    {
-    //        reader.Peek();
-    //        sb.Append((char)reader.Read());
-    //    }
+        while (reader.Peek() != -1)
+        {
+            reader.Peek();
+            sb.Append((char)reader.Read());
+        }
 
-    //    return sb.ToString();
-    //}
+        return sb.ToString();
+    }
 
-    //[Benchmark]
-    //public string ClassSpanStringReader()
-    //{
-    //    var sb = new StringBuilder();
-    //    var reader = new ClassSpanStringReader(CodeToParse);
+    [Benchmark]
+    public string ClassSpanStringReader()
+    {
+        var sb = new StringBuilder();
+        var reader = new ClassSpanStringReader(CodeToParse);
 
-    //    while (reader.Peek() != -1)
-    //    {
-    //        reader.Peek();
-    //        sb.Append(reader.Read());
-    //    }
+        while (reader.Peek() != -1)
+        {
+            reader.Peek();
+            sb.Append(reader.Read());
+        }
 
-    //    return sb.ToString();
-    //}
+        return sb.ToString();
+    }
 
-    //[Benchmark]
-    //public string StructSpanStringReader()
-    //{
-    //    var sb = new StringBuilder();
-    //    var reader = new StructSpanStringReader(CodeToParse);
+    [Benchmark]
+    public string StructSpanStringReader()
+    {
+        var sb = new StringBuilder();
+        var reader = new StructSpanStringReader(CodeToParse);
 
-    //    while (reader.Peek() != -1)
-    //    {
-    //        reader.Peek();
-    //        sb.Append((char)reader.Read());
-    //    }
+        while (reader.Peek() != -1)
+        {
+            reader.Peek();
+            sb.Append((char)reader.Read());
+        }
 
-    //    return sb.ToString();
-    //}
+        return sb.ToString();
+    }
 
     [Benchmark]
     public string StructSpanStringReaderInLibrary()
@@ -83,7 +83,7 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
         var sb = new StringBuilder();
         var reader = new StringSpanReader(CodeToParse);
 
-        while (reader.HasMoreCharacters)
+        while (reader.HasMoreCharacters())
         {
             reader.Peek();
             sb.Append(reader.Read());

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -17,7 +17,7 @@ public ref struct StringSpanReader
     private int Index { get; set; }
 
     public bool HasMoreCharacters() => Index < StringToParse.Length;
-    public char Peek() => StringToParse[Index];
+    public char? Peek() => HasMoreCharacters() ? StringToParse[Index] : null;
     public char Read() => StringToParse[Index++];
 
     public string? Peek(int numberOfCharacters) => PeekOrReadMultipleCharacters(numberOfCharacters);

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -52,13 +52,13 @@ public ref struct StringSpanReader
     {
         var tryToFindIndex = StringToParse.IndexOf(characterToLookFor, stringComparison);
 
-        if(tryToFindIndex == -1)
+        if (tryToFindIndex == -1)
         {
             return null;
         }
 
         var tempResult = new string(StringToParse.Slice(Index, tryToFindIndex));
-        
+
         //fast forward the index
         Index = tryToFindIndex;
 

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -37,6 +37,7 @@ public class StringSpanReaderTest
         Assert.Equal('b', reader.Read());
         Assert.Equal('c', reader.Peek());
         Assert.Equal('c', reader.Read());
+        Assert.Null(reader.Peek()); //shouldn't throw as we check if its the end of the string
     }
 
     [Fact]


### PR DESCRIPTION
For the string struct span reader - add a check when peeking to ensure we don't throw if we are at the eof. This way all the calling code doesn't need to add that. Performance doesn't really get affected.