### PR TITLE
Struct parse read until fix

### DIFF
--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -50,18 +50,21 @@ public ref struct StringSpanReader
 
     public string? ReadUntilCharacter(string characterToLookFor, StringComparison stringComparison)
     {
-        var tryToFindIndex = StringToParse.IndexOf(characterToLookFor, stringComparison);
+        //we could be in the middle of the reader. So we need to start from the index on
+        var stringFromIndexToEnd = StringToParse[Index..];
+
+        var tryToFindIndex = stringFromIndexToEnd.IndexOf(characterToLookFor, stringComparison);
 
         if (tryToFindIndex == -1)
         {
             return null;
         }
 
-        var tempResult = new string(StringToParse.Slice(Index, tryToFindIndex));
+        var tempResult = stringFromIndexToEnd.Slice(0,tryToFindIndex);
 
         //fast forward the index
         Index = tryToFindIndex;
 
-        return tempResult;
+        return new string(tempResult);
     }
 }

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -60,7 +60,8 @@ public ref struct StringSpanReader
             return null;
         }
 
-        var tempResult = stringFromIndexToEnd.Slice(0,tryToFindIndex);
+        //start from the first character and read until the index
+        var tempResult = stringFromIndexToEnd[..tryToFindIndex];
 
         //fast forward the index
         Index = tryToFindIndex;

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -64,6 +64,9 @@ public class StringSpanReaderTest
 
         //now make sure we are up to c
         Assert.Equal('c', reader.Peek());
+
+        //read some more
+        Assert.Equal("cd", reader.Read(2));
     }
 
     [Fact]
@@ -94,6 +97,19 @@ public class StringSpanReaderTest
 
         Assert.Equal("1 == 1 ", result);
         Assert.Equal('&', reader.Peek());
+    }
+
+    [Fact]
+    public void ReadUntilCharacterWhenFoundAndInMiddleOfString()
+    {
+        var reader = new StringSpanReader("1 == 1 && 2 == 2");
+
+        //skip until the second ==
+        Assert.Equal("1 ==", reader.Read(4));
+
+        var result = reader.ReadUntilCharacter("&&", StringComparison.OrdinalIgnoreCase);
+
+        Assert.Equal(" 1 ", result);
     }
 
     [Fact]


### PR DESCRIPTION
Struct parse read until fix. We weren't taking into account the index of when slicing the string.