### PR TITLE
RuleParser: Change the way parameters are to deal with non object parameters in the

### DIFF
--- a/Src/LibraryCore.Core/LibraryCore.Core.csproj
+++ b/Src/LibraryCore.Core/LibraryCore.Core.csproj
@@ -8,7 +8,7 @@
 	<ImplicitUsings>enable</ImplicitUsings>
     <Authors>Jason DiBianco</Authors>
     <Description>.NetCore Common Library</Description>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserCompilationResult.cs
+++ b/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserCompilationResult.cs
@@ -37,4 +37,9 @@ public class RuleParserCompilationResult
     /// </summary>
     public Expression<Func<T1, string>> BuildStringExpression<T1>(string parameter1Name) => StringOutputExpressionBuilder.BuildExpression<T1>(CompilationTokenResult, parameter1Name);
 
+    /// <summary>
+    /// Try to cache the compiled expression if this is used for a log 
+    /// </summary>
+    public Expression<Func<T1, T2, string>> BuildStringExpression<T1, T2>(string parameter1Name, string parameter2Name) => StringOutputExpressionBuilder.BuildExpression<T1, T2>(CompilationTokenResult, parameter1Name, parameter2Name);
+
 }

--- a/Src/LibraryCore.Core/Parsers/RuleParser/TokenFactories/Implementation/ParameterPropertyFactory.cs
+++ b/Src/LibraryCore.Core/Parsers/RuleParser/TokenFactories/Implementation/ParameterPropertyFactory.cs
@@ -54,11 +54,15 @@ public record ParameterPropertyToken(string? ParameterName, string PropertyName)
             return parameters[0];
         }
 
+        //if this is not an object ie: $MyInt$....then just use the parameters
+        if (ParameterName.IsNullOrEmpty())
+        {
+            return parameters.Single(x => x.Name?.Equals(PropertyName, StringComparison.OrdinalIgnoreCase) ?? throw new Exception("Property Name Not Found"));
+        }
+
         //if there is 1 parameter then we know which parameter they want so they can just do $Age and we know its off of $MyParameter. 
         //if there is more then 1 we need to search for that parameter
-        var parameterExpression = howManyParameters == 1 ?
-                                                        parameters[0] :
-                                                        parameters.SingleOrDefault(x => x.Name.HasValue() && x.Name.Equals(ParameterName, StringComparison.OrdinalIgnoreCase)) ?? throw new Exception($"Parameter Name Not Found: {ParameterName}");
+        var parameterExpression = parameters.Single(x => x.Name.HasValue() && x.Name.Equals(ParameterName, StringComparison.OrdinalIgnoreCase));
 
         return Expression.PropertyOrField(parameterExpression, PropertyName);
     }

--- a/Tests/LibraryCore.Tests.Core/Parsers/AttributeFormatParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/AttributeFormatParserTest.cs
@@ -112,4 +112,14 @@ public class AttributeFormatParserTest : IClassFixture<RuleParserFixture>
                                                          .Compile()
                                                          .Invoke(new Dictionary<string, object> { { "SaveRequest", new MockSaveRequest(1, 1, NestedObject: new MockSaveRequest(2, 2)) } }));
     }
+
+    [Fact]
+    public void MultipleParameterBuildExpression()
+    {
+        Assert.Equal("Parameter 1 = Value1 | Parameter 2 = Value2", RuleParserFixture.ResolveRuleParserEngine()
+                                                         .ParseString("'Parameter 1 = {$P1$} | Parameter 2 = {$P2$}'")
+                                                         .BuildStringExpression<string, string>("P1", "P2")
+                                                         .Compile()
+                                                         .Invoke("Value1", "Value2"));
+    }
 }

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/AndAlsoParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/AndAlsoParserTest.cs
@@ -42,14 +42,14 @@ public class AndAlsoParserTest : IClassFixture<RuleParserFixture>
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new AndAlsoToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
     //string
-    [InlineData("$Name$ == 'John Portal' && $Name$ == 'Bob'", false)]
-    [InlineData("$Name$ == 'John Portal' && $Name$ == 'Jacob DeGrom'", false)]
-    [InlineData("$Name$ == 'Jacob DeGrom' && $SurgeryCount$ == 100", false)]
-    [InlineData("$Name$ == 'Jacob DeGrom' && $SurgeryCount$ == 10", true)]
+    [InlineData("$Survey.Name$ == 'John Portal' && $Survey.Name$ == 'Bob'", false)]
+    [InlineData("$Survey.Name$ == 'John Portal' && $Survey.Name$ == 'Jacob DeGrom'", false)]
+    [InlineData("$Survey.Name$ == 'Jacob DeGrom' && $Survey.SurgeryCount$ == 100", false)]
+    [InlineData("$Survey.Name$ == 'Jacob DeGrom' && $Survey.SurgeryCount$ == 10", true)]
 
     //numbers
-    [InlineData("$SurgeryCount$ == 50 && $SurgeryCount$ == 10", false)]
-    [InlineData("$SurgeryCount$ == 10 && $PriceOfSurgery$ == 9.99d", true)]
+    [InlineData("$Survey.SurgeryCount$ == 50 && $Survey.SurgeryCount$ == 10", false)]
+    [InlineData("$Survey.SurgeryCount$ == 10 && $Survey.PriceOfSurgery$ == 9.99d", true)]
 
     [Theory]
     public void EqualExpression(string expressionToTest, bool expectedResult)

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/EqualParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/EqualParserTest.cs
@@ -31,11 +31,11 @@ public class EqualParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new EqualsToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
-    [InlineData("$PriceOfSurgery$ == 9.99d", true)]
-    [InlineData("$PriceOfSurgery$ == 8.25d", false)]
-    [InlineData("$PriceOfSurgery$ == 60d", false)]
-    [InlineData("$Name$ == 'Jacob DeGrom'", true)]
-    [InlineData("$Name$ == 'Tommy'", false)]
+    [InlineData("$Survey.PriceOfSurgery$ == 9.99d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ == 8.25d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ == 60d", false)]
+    [InlineData("$Survey.Name$ == 'Jacob DeGrom'", true)]
+    [InlineData("$Survey.Name$ == 'Tommy'", false)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, bool expectedResult)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/GreaterThenOrEqualParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/GreaterThenOrEqualParserTest.cs
@@ -31,9 +31,9 @@ public class GreaterThenOrEqualParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new GreaterThenOrEqualToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
-    [InlineData("$PriceOfSurgery$ >= 9.99d", true)]
-    [InlineData("$PriceOfSurgery$ >= 8.25d", true)]
-    [InlineData("$PriceOfSurgery$ >= 60d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ >= 9.99d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ >= 8.25d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ >= 60d", false)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, bool expectedResult)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/GreaterThenParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/GreaterThenParserTest.cs
@@ -31,9 +31,9 @@ public class GreaterThenParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new GreaterThenToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
-    [InlineData("$PriceOfSurgery$ > 9.99d", false)]
-    [InlineData("$PriceOfSurgery$ > 8.25d", true)]
-    [InlineData("$PriceOfSurgery$ > 60d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ > 9.99d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ > 8.25d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ > 60d", false)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, bool expectedResult)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/LessThenOrEqualParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/LessThenOrEqualParserTest.cs
@@ -31,9 +31,9 @@ public class LessThenOrEqualParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new LessThenOrEqualToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
-    [InlineData("$PriceOfSurgery$ <= 9.99d", true)]
-    [InlineData("$PriceOfSurgery$ <= 10d", true)]
-    [InlineData("$PriceOfSurgery$ <= 5d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ <= 9.99d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ <= 10d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ <= 5d", false)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, bool expectedResult)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/LessThenParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/LessThenParserTest.cs
@@ -31,9 +31,9 @@ public class LessThenParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new LessThenToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
-    [InlineData("$PriceOfSurgery$ < 9.99d", false)]
-    [InlineData("$PriceOfSurgery$ < 10d", true)]
-    [InlineData("$PriceOfSurgery$ < 5d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ < 9.99d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ < 10d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ < 5d", false)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, bool expectedResult)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/LikeParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/LikeParserTest.cs
@@ -32,9 +32,9 @@ public class LikeParserTest : IClassFixture<RuleParserFixture>
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new LikeToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
 
-    [InlineData("$Name$ like 'John'", false)]
-    [InlineData("$Name$ like 'John' || $SurgeryCount$ == 10", true)]
-    [InlineData("$Name$ like 'Jacob'", true)]
+    [InlineData("$Survey.Name$ like 'John'", false)]
+    [InlineData("$Survey.Name$ like 'John' || $Survey.SurgeryCount$ == 10", true)]
+    [InlineData("$Survey.Name$ like 'Jacob'", true)]
     [Theory]
     public void LikeTest(string expressionToTest, bool expectedResult)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/NotEqualParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/NotEqualParserTest.cs
@@ -31,8 +31,8 @@ public class NotEqualParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new NotEqualsToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
-    [InlineData("$Name$ != null", null, false)]
-    [InlineData("$Name$ != null", "abc", true)]
+    [InlineData("$Survey.Name$ != null", null, false)]
+    [InlineData("$Survey.Name$ != null", "abc", true)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, string nameValueToSet, bool expectedResult)
     {
@@ -49,7 +49,7 @@ public class NotEqualParserTest : IClassFixture<RuleParserFixture>
     public void ExpressionInLinq()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$Name$ != null && $Name$ != 'Jacob'")
+                                            .ParseString("$Survey.Name$ != null && $Survey.Name$ != 'Jacob'")
                                             .BuildExpression<Survey>("Survey")
                                             .Compile();
 

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/NullParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/NullParserTest.cs
@@ -27,10 +27,10 @@ public class NullParserTest : IClassFixture<RuleParserFixture>
         Assert.IsType<NullToken>(result[4]);
     }
 
-    [InlineData("$Name$ == null", null, true)]
-    [InlineData("$Name$ == null", "abc", false)]
-    [InlineData("$Name$ != null", null, false)]
-    [InlineData("$Name$ != null", "abc", true)]
+    [InlineData("$Survey.Name$ == null", null, true)]
+    [InlineData("$Survey.Name$ == null", "abc", false)]
+    [InlineData("$Survey.Name$ != null", null, false)]
+    [InlineData("$Survey.Name$ != null", "abc", true)]
     [Theory]
     public void ExpressionsToTest(string expressionToTest, string nameValueToSet, bool expectedResult)
     {
@@ -48,7 +48,7 @@ public class NullParserTest : IClassFixture<RuleParserFixture>
     public void ExpressionInLinq()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$Name$ == null || $Name$ == 'Jacob'")
+                                            .ParseString("$Survey.Name$ == null || $Survey.Name$ == 'Jacob'")
                                             .BuildExpression<Survey>("Survey")
                                             .Compile();
 

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/NumberParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/NumberParserTest.cs
@@ -65,18 +65,18 @@ public class NumberParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void DoubleNotParseable()
     {
-        var result = Assert.Throws<Exception>(() => RuleParserFixture.ResolveRuleParserEngine().ParseString("$Id$ == 12.32.23d"));
+        var result = Assert.Throws<Exception>(() => RuleParserFixture.ResolveRuleParserEngine().ParseString("$Survey.Id$ == 12.32.23d"));
 
         Assert.Equal("Number Factory [Double] Not Able To Parse Number. Value = 12.32.23", result.Message);
     }
 
-    [InlineData("$SurgeryCount$ >= 17", false)]
-    [InlineData("$SurgeryCount$ >= 10", true)]
-    [InlineData("$SurgeryCount$ > 10", false)]
-    [InlineData("$SurgeryCount$ <= 10", true)]
-    [InlineData("$SurgeryCount$ < 10", false)]
-    [InlineData("$SurgeryCount$ == 5", false)]
-    [InlineData("$SurgeryCount$ == 10", true)]
+    [InlineData("$Survey.SurgeryCount$ >= 17", false)]
+    [InlineData("$Survey.SurgeryCount$ >= 10", true)]
+    [InlineData("$Survey.SurgeryCount$ > 10", false)]
+    [InlineData("$Survey.SurgeryCount$ <= 10", true)]
+    [InlineData("$Survey.SurgeryCount$ < 10", false)]
+    [InlineData("$Survey.SurgeryCount$ == 5", false)]
+    [InlineData("$Survey.SurgeryCount$ == 10", true)]
     [Theory]
     public void IntExpressionsToTest(string expressionToTest, bool expectedResult)
     {
@@ -88,15 +88,15 @@ public class NumberParserTest : IClassFixture<RuleParserFixture>
         Assert.Equal(expectedResult, expression.Invoke(new SurveyModelBuilder().Value));
     }
 
-    [InlineData("$PriceOfSurgery$ >= 17d", false)]
-    [InlineData("$PriceOfSurgery$ >= 10d", false)]
-    [InlineData("$PriceOfSurgery$ >= 9.99d", true)]
-    [InlineData("$PriceOfSurgery$ > 10d", false)]
-    [InlineData("$PriceOfSurgery$ <= 10d", true)]
-    [InlineData("$PriceOfSurgery$ < 10d", true)]
-    [InlineData("$PriceOfSurgery$ == 5d", false)]
-    [InlineData("$PriceOfSurgery$ == 10d", false)]
-    [InlineData("$PriceOfSurgery$ == 9.99d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ >= 17d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ >= 10d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ >= 9.99d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ > 10d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ <= 10d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ < 10d", true)]
+    [InlineData("$Survey.PriceOfSurgery$ == 5d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ == 10d", false)]
+    [InlineData("$Survey.PriceOfSurgery$ == 9.99d", true)]
     [Theory]
     public void DoubleExpressionsToTest(string expressionToTest, bool expectedResult)
     {
@@ -112,7 +112,7 @@ public class NumberParserTest : IClassFixture<RuleParserFixture>
     public void ExpressionInLinq()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                               .ParseString("$SurgeryCount$ == 10 || $PriceOfSurgery$ == 9.95d")
+                                               .ParseString("$Survey.SurgeryCount$ == 10 || $Survey.PriceOfSurgery$ == 9.95d")
                                                .BuildExpression<Survey>("Survey")
                                                .Compile();
 

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/OrElseParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/OrElseParserTest.cs
@@ -42,15 +42,15 @@ public class OrElseParserTest : IClassFixture<RuleParserFixture>
     public void CreateTokenNotImplemented() => Assert.Throws<NotImplementedException>(() => new OrElseToken().CreateExpression(Array.Empty<ParameterExpression>()));
 
     //string
-    [InlineData("$Name$ == 'John Portal' || $Name$ == 'Bob'", false)]
-    [InlineData("$Name$ == 'John Portal' || $Name$ == 'Jacob DeGrom'", true)]
-    [InlineData("$SurgeryCount$ == 50 || $SurgeryCount$ == 100", false)]
+    [InlineData("$Survey.Name$ == 'John Portal' || $Survey.Name$ == 'Bob'", false)]
+    [InlineData("$Survey.Name$ == 'John Portal' || $Survey.Name$ == 'Jacob DeGrom'", true)]
+    [InlineData("$Survey.SurgeryCount$ == 50 || $Survey.SurgeryCount$ == 100", false)]
 
     //int
-    [InlineData("$SurgeryCount$ == 10 || $Name$ == 'Bob'", true)]
-    [InlineData("$SurgeryCount$ == 100 || $Name$ == 'Jacob DeGrom'", true)]
-    [InlineData("$SurgeryCount$ == 50 || $SurgeryCount$ == 10", true)]
-    [InlineData("$SurgeryCount$ == 50 || $SurgeryCount$ == 100 || $SurgeryCount$ == 10", true)]
+    [InlineData("$Survey.SurgeryCount$ == 10 || $Survey.Name$ == 'Bob'", true)]
+    [InlineData("$Survey.SurgeryCount$ == 100 || $Survey.Name$ == 'Jacob DeGrom'", true)]
+    [InlineData("$Survey.SurgeryCount$ == 50 || $Survey.SurgeryCount$ == 10", true)]
+    [InlineData("$Survey.SurgeryCount$ == 50 || $Survey.SurgeryCount$ == 100 || $Survey.SurgeryCount$ == 10", true)]
 
     [Theory]
     public void EqualExpression(string expressionToTest, bool expectedResult)

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/ParameterPropertyParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/ParameterPropertyParserTest.cs
@@ -32,28 +32,8 @@ public class ParameterPropertyParserTest : IClassFixture<RuleParserFixture>
         Assert.Equal("PatientName", firstParameterToken.PropertyName);
     }
 
-    [Fact]
-    public void ParseParameterWithShortHandParameterTest()
-    {
-        var result = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$PatientName$ == 1")
-                                            .CompilationTokenResult;
-
-        Assert.Equal(5, result.Count);
-        Assert.IsType<ParameterPropertyToken>(result[0]);
-        Assert.IsType<WhiteSpaceToken>(result[1]);
-        Assert.IsType<EqualsToken>(result[2]);
-        Assert.IsType<WhiteSpaceToken>(result[3]);
-        Assert.IsType<NumberToken<int>>(result[4]);
-
-        var firstParameterToken = (ParameterPropertyToken)result[0];
-
-        Assert.Null(firstParameterToken.ParameterName);
-        Assert.Equal("PatientName", firstParameterToken.PropertyName);
-    }
-
-    [InlineData("$Name$ == 'John Portal'", false)]
-    [InlineData("$Name$ == 'Jacob DeGrom'", true)]
+    [InlineData("$Survey.Name$ == 'John Portal'", false)]
+    [InlineData("$Survey.Name$ == 'Jacob DeGrom'", true)]
     [Theory]
     public void EqualExpression(string expressionToTest, bool expectedResult)
     {
@@ -69,7 +49,7 @@ public class ParameterPropertyParserTest : IClassFixture<RuleParserFixture>
     public void NonObjectParameter()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$Size$ == 25")
+                                            .ParseString("$Survey.Size$ == 25")
                                             .BuildExpression<int>("Size")
                                             .Compile();
 
@@ -91,7 +71,7 @@ public class ParameterPropertyParserTest : IClassFixture<RuleParserFixture>
     public void PropertyNameWithOneParameterWhichIsNotSpecifiedPositiveRule()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$SurgeryCount$ == 10")
+                                            .ParseString("$Survey.SurgeryCount$ == 10")
                                             .BuildExpression<Survey>("Survey")
                                             .Compile();
 
@@ -102,7 +82,7 @@ public class ParameterPropertyParserTest : IClassFixture<RuleParserFixture>
     public void EqualExpressionInLinq()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$Name$ == 'Jacob DeGrom'")
+                                            .ParseString("$Survey.Name$ == 'Jacob DeGrom'")
                                             .BuildExpression<Survey>("Survey")
                                             .Compile();
 

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/StringParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/StringParserTest.cs
@@ -53,13 +53,13 @@ public class StringParserTest : IClassFixture<RuleParserFixture>
     [Fact]
     public void StringWithNoClosingBracket()
     {
-        var result = Assert.Throws<Exception>(() => RuleParserFixture.ResolveRuleParserEngine().ParseString("$Name$ == 'noclosingbracket"));
+        var result = Assert.Throws<Exception>(() => RuleParserFixture.ResolveRuleParserEngine().ParseString("$Survey.Name$ == 'noclosingbracket"));
 
         Assert.Equal("Missing closing quote on String Value. Current Value = noclosingbracket", result.Message);
     }
 
-    [InlineData("$Name$ == 'John Portal'", false)]
-    [InlineData("$Name$ == 'Jacob DeGrom'", true)]
+    [InlineData("$Survey.Name$ == 'John Portal'", false)]
+    [InlineData("$Survey.Name$ == 'Jacob DeGrom'", true)]
     [Theory]
     public void EqualExpression(string expressionToTest, bool expectedResult)
     {
@@ -75,7 +75,7 @@ public class StringParserTest : IClassFixture<RuleParserFixture>
     public void ExpressionInLinq()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$Name$ == 'Jacob DeGrom'")
+                                            .ParseString("$Survey.Name$ == 'Jacob DeGrom'")
                                             .BuildExpression<Survey>("Survey")
                                             .Compile();
 


### PR DESCRIPTION
Rule Parser: In the parameter parser you always must preference the object in the syntax. ie: $ParameterName.PropertyName$