### PR TITLE
Rule Parser: Cleanup the parameter token create code. Should handle deep objects

### DIFF
--- a/Src/LibraryCore.Core/LibraryCore.Core.csproj
+++ b/Src/LibraryCore.Core/LibraryCore.Core.csproj
@@ -8,7 +8,7 @@
 	<ImplicitUsings>enable</ImplicitUsings>
     <Authors>Jason DiBianco</Authors>
     <Description>.NetCore Common Library</Description>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
     <RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserEngine.cs
+++ b/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserEngine.cs
@@ -30,6 +30,7 @@ public class RuleParserEngine
 
     //Parameter / Methods Calls
     //$ParameterName.PropertyName$ Of a property passed in
+    //$MyBooleanParameter if the parameter is not an object. ie: $MyBooleanParameter == true
     //@MethodCall(1,true, 'sometext') <-- need to register the method in MethodCallFactory.RegisterNewMethodAlias. That says "MethodCall" goes to this method in this namespace
 
     //Comparison

--- a/Src/LibraryCore.Core/Parsers/RuleParser/TokenFactories/Implementation/ParameterPropertyFactory.cs
+++ b/Src/LibraryCore.Core/Parsers/RuleParser/TokenFactories/Implementation/ParameterPropertyFactory.cs
@@ -27,7 +27,7 @@ public class ParameterPropertyFactory : ITokenFactory
     }
 }
 
-[DebuggerDisplay("Parameter Property Name = {ParameterName}.{PropertyName}")]
+[DebuggerDisplay("Parameter Property Path = {DebuggerDisplay()}")]
 public record ParameterPropertyToken(IList<string> PropertyPath) : IToken
 {
     public Expression CreateExpression(IList<ParameterExpression> parameters)
@@ -40,11 +40,14 @@ public record ParameterPropertyToken(IList<string> PropertyPath) : IToken
         //loop through each level and keep grabbing the next level
         Expression workingExpression = parameters.Single(x => x.Name == PropertyPath[0]);
 
-        foreach(var propertyLevel in PropertyPath.Skip(1))
+        foreach (var propertyLevel in PropertyPath.Skip(1))
         {
             workingExpression = Expression.PropertyOrField(workingExpression, propertyLevel);
         }
 
         return workingExpression;
     }
+
+    private string DebuggerDisplay() => string.Join('.', PropertyPath);
+
 }

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Fixtures/SurveyModelBuilder.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Fixtures/SurveyModelBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace LibraryCore.Tests.Core.Parsers.RuleParser.Fixtures;
 
-public record Survey(string Name, int SurgeryCount, double PriceOfSurgery, DateTime DateOfBirth, DateTime? LastLogin, bool CanDrive, bool? HasAccount, int? NumberOfMotorcyles, double? NumberOfBoats, IDictionary<int, string> Answers);
+public record Survey(string Name, int SurgeryCount, double PriceOfSurgery, DateTime DateOfBirth, DateTime? LastLogin, bool CanDrive, bool? HasAccount, int? NumberOfMotorcyles, double? NumberOfBoats, IDictionary<int, string> Answers, Survey? InnerSurvey);
 
 public class SurveyModelBuilder
 {
@@ -11,7 +11,7 @@ public class SurveyModelBuilder
             { 1, "Yes" },
             { 2, "No" },
             { 3, "Maybe" }
-        });
+        }, null);
     }
 
     public Survey Value { get; set; }
@@ -26,6 +26,7 @@ public class SurveyModelBuilder
     public SurveyModelBuilder WithHasAccount(bool? value) => SetAndReturn(Value with { HasAccount = value });
     public SurveyModelBuilder WithNumberOfMotorcycles(int? value) => SetAndReturn(Value with { NumberOfMotorcyles = value });
     public SurveyModelBuilder WithNumberOfBoats(double? value) => SetAndReturn(Value with { NumberOfBoats = value });
+    public SurveyModelBuilder WithInnerSurveyObject(Survey innerSurvey) => SetAndReturn(Value with { InnerSurvey = innerSurvey });
 
     public static IEnumerable<Survey> CreateArrayOfRecords(params SurveyModelBuilder[] surveyModelBuilders)
     {

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/ParameterPropertyParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/ParameterPropertyParserTest.cs
@@ -50,7 +50,7 @@ public class ParameterPropertyParserTest : IClassFixture<RuleParserFixture>
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
                                             .ParseString("$Survey.Size$ == 25")
-                                            .BuildExpression<int>("Size")
+                                            .BuildExpression<int>("Survey")
                                             .Compile();
 
         Assert.True(expression.Invoke(25));

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/ParameterPropertyParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/Tokens/ParameterPropertyParserTest.cs
@@ -49,8 +49,8 @@ public class ParameterPropertyParserTest : IClassFixture<RuleParserFixture>
     public void NonObjectParameter()
     {
         var expression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseString("$Survey.Size$ == 25")
-                                            .BuildExpression<int>("Survey")
+                                            .ParseString("$Size$ == 25")
+                                            .BuildExpression<int>("Size")
                                             .Compile();
 
         Assert.True(expression.Invoke(25));


### PR DESCRIPTION
Rule Parser: Cleanup the parameter token create code. Issues in the current code couldn't handle nested object property paths. This should resolve that.