### PR TITLE
Adjust the batch command for performance tests

### DIFF
--- a/Commands/RunPerformanceTest.bat
+++ b/Commands/RunPerformanceTest.bat
@@ -1,4 +1,5 @@
 cd..
 
+set /p test="Enter the test name to run: "
 dotnet build --configuration release
-dotnet run --configuration release --project PerformanceTests\LibraryCore.Performance.Tests
+dotnet run --configuration release --project PerformanceTests\LibraryCore.Performance.Tests %test%


### PR DESCRIPTION
Adjust the batch command for performance tests. This consume the test name and run the test directly using 'commands/RunPerformanceTest.bat'