### PR TITLE
Score Parser - Fix the method name and remove the "new".

### DIFF
--- a/Src/LibraryCore.Core/LibraryCore.Core.csproj
+++ b/Src/LibraryCore.Core/LibraryCore.Core.csproj
@@ -8,7 +8,7 @@
 	<ImplicitUsings>enable</ImplicitUsings>
     <Authors>Jason DiBianco</Authors>
     <Description>.NetCore Common Library</Description>
-    <Version>4.0.4</Version>
+    <Version>4.0.5</Version>
     <RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserCompilationResult.cs
+++ b/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserCompilationResult.cs
@@ -128,13 +128,5 @@ public class RuleParserCompilationResult<TResult>
         return Expression.Lambda<Func<T1, T2, TResult>>(RuleParserExpressionBuilder.CreateRuleExpression<TResult>(scoringMode, CompilationTokenResult, parametersToUse), parametersToUse);
     }
 
-    private static bool IsValidScoringMode(ScoringMode scoringMode)
-    {
-        if (scoringMode == ScoringMode.ShortCircuitOnFirstTrueEval)
-        {
-            return true;
-        }
-
-        return PrimitiveTypes.NumberTypesSelect().Contains(typeof(TResult));
-    }
+    private static bool IsValidScoringMode(ScoringMode scoringMode) => scoringMode == ScoringMode.ShortCircuitOnFirstTrueEval || PrimitiveTypes.NumberTypesSelect().Contains(typeof(TResult));
 }

--- a/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserEngine.cs
+++ b/Src/LibraryCore.Core/Parsers/RuleParser/RuleParserEngine.cs
@@ -70,7 +70,7 @@ public class RuleParserEngine
         return new RuleParserCompilationResult(tokens.ToImmutableList());
     }
 
-    public RuleParserCompilationResult<TScoreType> ParseScoreNew<TScoreType>(params ScoringCriteriaParameter<TScoreType>[] scoreCriteria)
+    public RuleParserCompilationResult<TScoreType> ParseScore<TScoreType>(params ScoringCriteriaParameter<TScoreType>[] scoreCriteria)
     {
         return new RuleParserCompilationResult<TScoreType>(scoreCriteria.Select(t => (IToken)new ScoreCriteriaToken<TScoreType>(t.ScoreValueIfTrue, ParseString(t.ScoreTruthCriteria).CompilationTokenResult)).ToImmutableList());
     }

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/ScoreParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/ScoreParserTest.cs
@@ -28,7 +28,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
         Assert.Throws<ArgumentOutOfRangeException>(() =>
         {
             _ = RuleParserFixture.ResolveRuleParserEngine()
-                                          .ParseScoreNew<string>(
+                                          .ParseScore<string>(
                                                   new("a", "$User.Age$ < 18"),
                                                   new("b", "$User.Age$ >= 18 && $User.Age$ < 20"),
                                                   new("c", "$User.Age$ >= 20"))
@@ -45,7 +45,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
     public void IntBasedScore_ShortCircuitOnFirstTrueEval(int expectedScore, int Age)
     {
         var compiledExpression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseScoreNew<int>(
+                                            .ParseScore<int>(
                                                     new(-1, "$User.Age$ < 18"),
                                                     new(25, "$User.Age$ >= 18 && $User.Age$ < 20"),
                                                     new(50, "$User.Age$ >= 20"))
@@ -66,7 +66,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
     public void IntBasedScore_AccumulatedScore(int expectedScore, int Age)
     {
         var compiledExpression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseScoreNew<int>(
+                                            .ParseScore<int>(
                                                     new(1, "$User.Age$ > 3"),
                                                     new(25, "$User.Age$ > 10 && $User.Age$ < 100"),
                                                     new(50, "$User.Age$ > 20"))
@@ -86,7 +86,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
     public void StringBasedScore_ShortCircuitOnFirstTrueEval(string expectedScore, int Age)
     {
         var compiledExpression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseScoreNew<string>(
+                                            .ParseScore<string>(
                                                     new("A", "$User.Age$ == 10"),
                                                     new("B", "$User.Age$ == 20"),
                                                     new("C", "$User.Age$ == 30"),
@@ -106,7 +106,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
     public void EnumBasedScore_ShortCircuitOnFirstTrueEval(RiskOfHeartAttackScore expectedScore, int Age)
     {
         var compiledExpression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseScoreNew<RiskOfHeartAttackScore>(
+                                            .ParseScore<RiskOfHeartAttackScore>(
                                                     new(RiskOfHeartAttackScore.Low, "$User.Age$ < 20"),
                                                     new(RiskOfHeartAttackScore.Medium, "$User.Age$ >= 21 && $User.Age$ < 40"),
                                                     new(RiskOfHeartAttackScore.High, "$User.Age$ >= 40"))
@@ -126,7 +126,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
     public void WithMethodCall(int expectedScore, int Age)
     {
         var compiledExpression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseScoreNew<int>(
+                                            .ParseScore<int>(
                                                     new(-1, "@ScoreParser.GetAge($User$) < 18"),
                                                     new(25, "@ScoreParser.GetAge($User$) >= 18 && @ScoreParser.GetAge($User$) < 20"),
                                                     new(50, "@ScoreParser.GetAge($User$) >= 20"))
@@ -145,7 +145,7 @@ public class ScoreParserTest : IClassFixture<RuleParserFixture>
     public void MultiParameterTest(int expectedScore, int Age, int WeightInLbs)
     {
         var compiledExpression = RuleParserFixture.ResolveRuleParserEngine()
-                                            .ParseScoreNew<int>(
+                                            .ParseScore<int>(
                                                     new(25, "$User.Age$ == 18 && $Weight$ < 150"),
                                                     new(50, "$User.Age$ == 18 && $Weight$ > 150"))
                                             .BuildScoreExpression<ScoreParserModel, int>(ScoringMode.ShortCircuitOnFirstTrueEval, "User", "Weight")

--- a/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/ScoreParserTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Parsers/RuleParser/ScoreParserTest.cs
@@ -1,5 +1,4 @@
-﻿using LibraryCore.Core.Parsers.RuleParser.TokenFactories.Implementation;
-using LibraryCore.Tests.Core.Parsers.RuleParser.Fixtures;
+﻿using LibraryCore.Tests.Core.Parsers.RuleParser.Fixtures;
 using static LibraryCore.Core.Parsers.RuleParser.TokenFactories.Implementation.ScoreToken;
 
 namespace LibraryCore.Tests.Core.Parsers.RuleParser;


### PR DESCRIPTION
The score parser had a random "new" on the parse method name. Removing it.