### PR TITLE
Nullable reference warning test projects

### DIFF
--- a/IntegrationTests/LibraryCore.IntegrationTests/LibraryCore.IntegrationTests.csproj
+++ b/IntegrationTests/LibraryCore.IntegrationTests/LibraryCore.IntegrationTests.csproj
@@ -6,6 +6,7 @@
 	  <LangVersion>latest</LangVersion>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
+	  <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/Tests/LibraryCore.Tests.AspNet/Attribution/CustomAttributeTest.cs
+++ b/Tests/LibraryCore.Tests.AspNet/Attribution/CustomAttributeTest.cs
@@ -29,13 +29,13 @@ public class CustomAttributeTest
     [Fact]
     public void CustomAttributeIsDefined()
     {
-        Assert.True(CustomAttributes.CustomAttributeIsDefined<MyTestAttribute>(new ControllerActionDescriptor { MethodInfo = typeof(TestController).GetMethod(nameof(TestController.IndexWithAttribute)) }));
+        Assert.True(CustomAttributes.CustomAttributeIsDefined<MyTestAttribute>(new ControllerActionDescriptor { MethodInfo = typeof(TestController).GetMethod(nameof(TestController.IndexWithAttribute)) ?? throw new Exception("Can't Find Method") }));
     }
 
     [Fact]
     public void CustomAttributeIsNotDefined()
     {
-        Assert.False(CustomAttributes.CustomAttributeIsDefined<MyTestAttribute>(new ControllerActionDescriptor { MethodInfo = typeof(TestController).GetMethod(nameof(TestController.Index)) }));
+        Assert.False(CustomAttributes.CustomAttributeIsDefined<MyTestAttribute>(new ControllerActionDescriptor { MethodInfo = typeof(TestController).GetMethod(nameof(TestController.Index)) ?? throw new Exception("Can't Find Method") }));
     }
 
     [Fact]

--- a/Tests/LibraryCore.Tests.AspNet/LibraryCore.Tests.AspNet.csproj
+++ b/Tests/LibraryCore.Tests.AspNet/LibraryCore.Tests.AspNet.csproj
@@ -6,6 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<WarningsAsErrors>nullable</WarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tests/LibraryCore.Tests.Core/LibraryCore.Tests.Core.csproj
+++ b/Tests/LibraryCore.Tests.Core/LibraryCore.Tests.Core.csproj
@@ -6,6 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<WarningsAsErrors>nullable</WarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tests/LibraryCore.Tests.JsonNet/LibraryCore.Tests.JsonNet.csproj
+++ b/Tests/LibraryCore.Tests.JsonNet/LibraryCore.Tests.JsonNet.csproj
@@ -6,6 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<WarningsAsErrors>nullable</WarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
1. Switch warnings to errors
2. Resolve 2 spots in the test project where the warnings (not errors) where being raised.