### PR TITLE
Struct string reader bug fix. Perf tests for the delimiter parser.

### DIFF
--- a/PerformanceTests/LibraryCore.Performance.Tests/PerfTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
+++ b/PerformanceTests/LibraryCore.Performance.Tests/PerfTests/StringReaderVsSpan/StringReaderVsSpanReadPerfTest.cs
@@ -87,8 +87,8 @@ public class StringReaderVsSpanReadPerfTest : IPerformanceTest
 
         while (reader.HasMoreCharacters())
         {
-            reader.Peek();
-            sb.Append(reader.Read());
+            reader.PeekCharacter();
+            sb.Append(reader.ReadCharacter());
         }
 
         return sb.ToString();

--- a/Src/LibraryCore.Core/LibraryCore.Core.csproj
+++ b/Src/LibraryCore.Core/LibraryCore.Core.csproj
@@ -8,7 +8,7 @@
 	<ImplicitUsings>enable</ImplicitUsings>
     <Authors>Jason DiBianco</Authors>
     <Description>.NetCore Common Library</Description>
-    <Version>4.0.8</Version>
+    <Version>4.0.9</Version>
     <RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -17,12 +17,12 @@ public ref struct StringSpanReader
     private int Index { get; set; }
 
     public bool HasMoreCharacters() => Index < StringToParse.Length;
-    public char? Peek() => HasMoreCharacters() ? StringToParse[Index] : null;
-    public char Read() => StringToParse[Index++];
+    public char? PeekCharacter() => HasMoreCharacters() ? StringToParse[Index] : null;
+    public char ReadCharacter() => StringToParse[Index++];
 
-    public string? Peek(int numberOfCharacters) => PeekOrReadMultipleCharacters(numberOfCharacters);
+    public string? PeekCharacter(int numberOfCharacters) => PeekOrReadMultipleCharacters(numberOfCharacters);
 
-    public string? Read(int numberOfCharacters)
+    public string? ReadCharacter(int numberOfCharacters)
     {
         var readCharacters = PeekOrReadMultipleCharacters(numberOfCharacters);
 

--- a/Src/LibraryCore.Core/Readers/StringSpanReader.cs
+++ b/Src/LibraryCore.Core/Readers/StringSpanReader.cs
@@ -1,8 +1,7 @@
 ﻿namespace LibraryCore.Core.Readers;
 
 /// <summary>
-/// This a strict ensure you pass a ref value into any methods otherwise, the Index get's copied resulting in weird issues.
-/// This is faster by a string reader by 2x.
+/// This is faster by a string reader by 2x. Always pass this into a method by ref to avoid copy cost. Always benchmark this over string reader but is faster based on tests
 /// </summary>
 /// <remarks>See StringReaderVsSpanReadPerfTest for the performance test</remarks>
 public ref struct StringSpanReader
@@ -60,12 +59,10 @@ public ref struct StringSpanReader
             return null;
         }
 
+        //fast forward the index (because we are working with just the index on...we need to += to fast forward from the index plus whatever the smaller string we are scanning)
+        Index+= tryToFindIndex;
+
         //start from the first character and read until the index
-        var tempResult = stringFromIndexToEnd[..tryToFindIndex];
-
-        //fast forward the index
-        Index = tryToFindIndex;
-
-        return new string(tempResult);
+        return new string(stringFromIndexToEnd[..tryToFindIndex]);
     }
 }

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -120,4 +120,21 @@ public class StringSpanReaderTest
         Assert.Null(reader.ReadUntilCharacter("abc", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void ReadUntilCharacterWhenMultipleCharactersAreFound()
+    {
+        var reader = new StringSpanReader("111,222,333");
+
+        //move until we are in the middle of the string
+        reader.ReadCharacter(6);
+
+        var readUntilLastComma = reader.ReadUntilCharacter(",", StringComparison.OrdinalIgnoreCase);
+
+        //it shouldn't pick the 111
+        Assert.Equal("2", readUntilLastComma);
+
+        //the reader should be at the , now...not 1
+        Assert.Equal(',', reader.ReadCharacter());
+    }
+
 }

--- a/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
+++ b/Tests/LibraryCore.Tests.Core/Readers/StringSpanReaderTest.cs
@@ -9,9 +9,9 @@ public class StringSpanReaderTest
     {
         var reader = new StringSpanReader("Abc");
 
-        Assert.Equal('A', reader.Read());
-        Assert.Equal('b', reader.Read());
-        Assert.Equal('c', reader.Read());
+        Assert.Equal('A', reader.ReadCharacter());
+        Assert.Equal('b', reader.ReadCharacter());
+        Assert.Equal('c', reader.ReadCharacter());
     }
 
     [Fact]
@@ -20,9 +20,9 @@ public class StringSpanReaderTest
         var reader = new StringSpanReader("bc");
 
         Assert.True(reader.HasMoreCharacters());
-        reader.Read(); //should be at c
+        reader.ReadCharacter(); //should be at c
         Assert.True(reader.HasMoreCharacters());
-        reader.Read(); //should be after c
+        reader.ReadCharacter(); //should be after c
         Assert.False(reader.HasMoreCharacters());
     }
 
@@ -31,42 +31,42 @@ public class StringSpanReaderTest
     {
         var reader = new StringSpanReader("Abc");
 
-        Assert.Equal('A', reader.Peek());
-        Assert.Equal('A', reader.Read());
-        Assert.Equal('b', reader.Peek());
-        Assert.Equal('b', reader.Read());
-        Assert.Equal('c', reader.Peek());
-        Assert.Equal('c', reader.Read());
-        Assert.Null(reader.Peek()); //shouldn't throw as we check if its the end of the string
+        Assert.Equal('A', reader.PeekCharacter());
+        Assert.Equal('A', reader.ReadCharacter());
+        Assert.Equal('b', reader.PeekCharacter());
+        Assert.Equal('b', reader.ReadCharacter());
+        Assert.Equal('c', reader.PeekCharacter());
+        Assert.Equal('c', reader.ReadCharacter());
+        Assert.Null(reader.PeekCharacter()); //shouldn't throw as we check if its the end of the string
     }
 
     [Fact]
-    public void PeekMultipleWhenNotEnoughCharacters() => Assert.Equal("Abc", new StringSpanReader("Abc").Peek(5));
+    public void PeekMultipleWhenNotEnoughCharacters() => Assert.Equal("Abc", new StringSpanReader("Abc").PeekCharacter(5));
 
     [Fact]
-    public void PeekMultipleWhenAtTheEnd() => Assert.Null(new StringSpanReader("").Peek(1));
+    public void PeekMultipleWhenAtTheEnd() => Assert.Null(new StringSpanReader("").PeekCharacter(1));
 
     [Fact]
-    public void PeekMultipleWhenHaveCharactersLeftOverAfterPeek() => Assert.Equal("Ab", new StringSpanReader("Abcdef").Peek(2));
+    public void PeekMultipleWhenHaveCharactersLeftOverAfterPeek() => Assert.Equal("Ab", new StringSpanReader("Abcdef").PeekCharacter(2));
 
     [Fact]
-    public void ReadMultipleWhenNotEnoughCharacters() => Assert.Equal("Abc", new StringSpanReader("Abc").Read(5));
+    public void ReadMultipleWhenNotEnoughCharacters() => Assert.Equal("Abc", new StringSpanReader("Abc").ReadCharacter(5));
 
     [Fact]
-    public void ReadMultipleWhenAtTheEnd() => Assert.Null(new StringSpanReader("").Read(1));
+    public void ReadMultipleWhenAtTheEnd() => Assert.Null(new StringSpanReader("").ReadCharacter(1));
 
     [Fact]
     public void ReadMultipleWhenHaveCharactersLeftOverAfterPeek()
     {
         var reader = new StringSpanReader("Abcdef");
 
-        Assert.Equal("Ab", reader.Read(2));
+        Assert.Equal("Ab", reader.ReadCharacter(2));
 
         //now make sure we are up to c
-        Assert.Equal('c', reader.Peek());
+        Assert.Equal('c', reader.PeekCharacter());
 
         //read some more
-        Assert.Equal("cd", reader.Read(2));
+        Assert.Equal("cd", reader.ReadCharacter(2));
     }
 
     [Fact]
@@ -74,19 +74,19 @@ public class StringSpanReaderTest
     {
         var reader = new StringSpanReader("Abcdef");
 
-        Assert.Equal('A', reader.Read());
+        Assert.Equal('A', reader.ReadCharacter());
 
         PassStruct1(ref reader);
-        Assert.Equal('d', reader.Read());
+        Assert.Equal('d', reader.ReadCharacter());
     }
 
     private static void PassStruct1(ref StringSpanReader reader)
     {
-        Assert.Equal('b', reader.Read());
+        Assert.Equal('b', reader.ReadCharacter());
         PassStruct2(ref reader);
     }
 
-    private static void PassStruct2(ref StringSpanReader reader) => Assert.Equal('c', reader.Read());
+    private static void PassStruct2(ref StringSpanReader reader) => Assert.Equal('c', reader.ReadCharacter());
 
     [Fact]
     public void ReadUntilCharacterWhenFound()
@@ -96,7 +96,7 @@ public class StringSpanReaderTest
         var result = reader.ReadUntilCharacter("&&", StringComparison.OrdinalIgnoreCase);
 
         Assert.Equal("1 == 1 ", result);
-        Assert.Equal('&', reader.Peek());
+        Assert.Equal('&', reader.PeekCharacter());
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class StringSpanReaderTest
         var reader = new StringSpanReader("1 == 1 && 2 == 2");
 
         //skip until the second ==
-        Assert.Equal("1 ==", reader.Read(4));
+        Assert.Equal("1 ==", reader.ReadCharacter(4));
 
         var result = reader.ReadUntilCharacter("&&", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
- Struct string reader bug fix - when ReadUntil when the same character is earlier in the full string. The reader will reset the index to an earlier point then when you called the method.

- Performance tests for the delimiter parser