### PR TITLE
Command Line Parser Cleanup

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0
       with:
-        files: ./Tests/LibraryCore.Tests.JsonNet/coverage.opencover.xml,./Tests/LibraryCore.Tests.Core/coverage.opencover.xml,./Tests/LibraryCore.Tests.AspNet/coverage.opencover.xml,./Tests/LibraryCore.CommandLineParser/coverage.opencover.xml # optional
+        files: ./Tests/LibraryCore.Tests.JsonNet/coverage.opencover.xml,./Tests/LibraryCore.Tests.Core/coverage.opencover.xml,./Tests/LibraryCore.Tests.AspNet/coverage.opencover.xml,./Tests/LibraryCore.Tests.CommandLineParser/coverage.opencover.xml # optional
         fail_ci_if_error: true # optional (default = false)
 

--- a/Src/LibraryCore.CommandLineParser/LibraryCore.CommandLineParser.csproj
+++ b/Src/LibraryCore.CommandLineParser/LibraryCore.CommandLineParser.csproj
@@ -13,4 +13,8 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\LibraryCore.Core\LibraryCore.Core.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/Src/LibraryCore.CommandLineParser/LibraryCore.CommandLineParser.csproj
+++ b/Src/LibraryCore.CommandLineParser/LibraryCore.CommandLineParser.csproj
@@ -8,7 +8,7 @@
 		<WarningsAsErrors>nullable</WarningsAsErrors>
 		<Authors>Jason DiBianco</Authors>
 		<Description>Command Line Parser</Description>
-		<Version>0.0.1</Version>
+		<Version>0.0.2</Version>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/Src/LibraryCore.CommandLineParser/Runner.cs
+++ b/Src/LibraryCore.CommandLineParser/Runner.cs
@@ -1,5 +1,6 @@
 ﻿using LibraryCore.CommandLineParser.DefaultCommands;
 using LibraryCore.CommandLineParser.Options;
+using LibraryCore.Core.ExtensionMethods;
 using System.Collections.Immutable;
 
 namespace LibraryCore.CommandLineParser;
@@ -33,7 +34,7 @@ public static class Runner
         verboseModeWriter($"Command To Invoke = {commandToRun.CommandName}");
 
         //sub command help
-        if (FindIndex(commandArgs.Skip(1), x => x == helpCommand) > -1)
+        if (commandArgs.Skip(1).FirstIndexOfElement(x => x == helpCommand).HasValue)
         {
             Console.WriteLine(HelpCommand.HelpMenuTextForSubCommand(commandToRun));
             return 0;
@@ -63,7 +64,7 @@ public static class Runner
 
         foreach (var optionalArgRegistered in commandToRun.OptionalArguments)
         {
-            var indexOfCommand = FindIndex(commandArgs, x => string.Equals(x, optionalArgRegistered.Flag, StringComparison.OrdinalIgnoreCase));
+            var indexOfCommand = commandArgs.FirstIndexOfElement(x => string.Equals(x, optionalArgRegistered.Flag, StringComparison.OrdinalIgnoreCase)) ?? -1;
 
             if (indexOfCommand > -1)
             {
@@ -106,22 +107,5 @@ public static class Runner
         verboseModeWriter(string.Join(Environment.NewLine, temp.Select(t => $"Required Parameter Name = {t.Command.CommandName} | Value = {t.Value}")));
 
         return temp.ToDictionary(x => x.Command.CommandName, x => x.Value);
-    }
-
-    private static int FindIndex<T>(IEnumerable<T> listOfT, Func<T, bool> predicate)
-    {
-        int i = 0;
-
-        foreach (var item in listOfT)
-        {
-            if (predicate(item))
-            {
-                return i;
-            }
-
-            i++;
-        }
-
-        return -1;
     }
 }


### PR DESCRIPTION
1. Reference core project and remove duplicate code
2. Fix code coverage report not showing up for command line project
3. Bump command line package version.