### PR TITLE
Remove depreciated packages & use nuget packages

### DIFF
--- a/PerformanceTests/LibraryCore.Performance.Tests/LibraryCore.Performance.Tests.csproj
+++ b/PerformanceTests/LibraryCore.Performance.Tests/LibraryCore.Performance.Tests.csproj
@@ -10,11 +10,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-		<PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\..\Src\LibraryCore.CommandLineParser\LibraryCore.CommandLineParser.csproj" />
 		<ProjectReference Include="..\..\Src\LibraryCore.Core\LibraryCore.Core.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
- Performance Test - Remove depreciated package and use our own command line parser.

- use nuget packages when we reference packages in the solution,