### PR TITLE
AspNet - DistributedSession - Use the options when deserializing the inner object for useAutoTypeHandling

### DIFF
--- a/Src/LibraryCore.AspNet/LibraryCore.AspNet.csproj
+++ b/Src/LibraryCore.AspNet/LibraryCore.AspNet.csproj
@@ -11,7 +11,7 @@
 		<Description>AspNet Core Common Library</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>4.2.0</Version>
+		<Version>4.2.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Src/LibraryCore.AspNet/SessionState/DistributedSessionStateService.cs
+++ b/Src/LibraryCore.AspNet/SessionState/DistributedSessionStateService.cs
@@ -116,7 +116,7 @@ public class DistributedSessionStateService : ISessionStateService
 
             Type typeToDeserialize = CachedAutoTypeLookup.GetOrAdd(temp.FullTypePath, (path) => Type.GetType(path) ?? throw new Exception("Type Not Found: " + temp.FullTypePath));
 
-            var tempBeforeCast = JsonSerializer.Deserialize(temp.ValueInBytes, typeToDeserialize);
+            var tempBeforeCast = JsonSerializer.Deserialize(temp.ValueInBytes, typeToDeserialize, JsonSerializationOption);
 
             return tempBeforeCast == null ?
                         default :


### PR DESCRIPTION
AspNet - DistributedSession - Use the options when deserializing the inner object for derived classes / interfaces (useAutoTypeHandling)