### PR TITLE
Fix nuget token action.

### DIFF
--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -22,7 +22,7 @@ jobs:
       run:  dotnet pack --configuration Release
 
     - name: Prep Auth For NuGet
-      run: dotnet nuget add source --username dibiancoj@gmail.com --password ${{ secrets.GITHUB_TOKEN }} --name github "https://nuget.pkg.github.com/dibiancoj/index.json"
+      run: dotnet nuget add source --username dibiancoj@gmail.com --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/dibiancoj/index.json"
 
     - name: Push The Nuget Build
       run:  dotnet nuget push "**/*.nupkg" --source "github" --api-key ${GITHUB_TOKEN} --skip-duplicate

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Push The Nuget Build
       env:
         MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${{ secrets.MY_GITHUB_TOKEN }} --skip-duplicate
+      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key $MY_GITHUB_TOKEN --skip-duplicate

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -19,4 +19,6 @@ jobs:
     - name: Package The Build
       run:  dotnet pack --configuration Release
     - name: Push The Nuget Build
-      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${GITHUB_TOKEN} --skip-duplicate
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -12,13 +12,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 7.x
+
     - name: Package The Build
       run:  dotnet pack --configuration Release
+
+    - name: Prep Auth For NuGet
+      run: dotnet nuget add source --username dibiancoj@gmail.com --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/dibiancoj/index.json"
+
     - name: Push The Nuget Build
-      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${GITHUB_TOKEN} --skip-duplicate
+      run:  dotnet nuget push "**/*.nupkg" --source "github" --api-key ${GITHUB_TOKEN} --skip-duplicate
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -19,6 +19,4 @@ jobs:
     - name: Package The Build
       run:  dotnet pack --configuration Release
     - name: Push The Nuget Build
-      env:
-        MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key $MY_GITHUB_TOKEN --skip-duplicate
+      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Package The Build
       run:  dotnet pack --configuration Release
     - name: Push The Nuget Build
-      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+      run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${{ secrets.MY_GITHUB_TOKEN }} --skip-duplicate

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -22,7 +22,7 @@ jobs:
       run:  dotnet pack --configuration Release
 
     - name: Prep Auth For NuGet
-      run: dotnet nuget add source --username dibiancoj@gmail.com --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/dibiancoj/index.json"
+      run: dotnet nuget add source --username dibiancoj@gmail.com --password ${{ secrets.GITHUB_TOKEN }} --name github "https://nuget.pkg.github.com/dibiancoj/index.json"
 
     - name: Push The Nuget Build
       run:  dotnet nuget push "**/*.nupkg" --source "github" --api-key ${GITHUB_TOKEN} --skip-duplicate

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -19,4 +19,6 @@ jobs:
     - name: Package The Build
       run:  dotnet pack --configuration Release
     - name: Push The Nuget Build
+      env:
+        MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run:  dotnet nuget push "**/*.nupkg" --source "https://nuget.pkg.github.com/dibiancoj/index.json" --api-key ${{ secrets.MY_GITHUB_TOKEN }} --skip-duplicate

--- a/.github/workflows/CoreNuget.yml
+++ b/.github/workflows/CoreNuget.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Package The Build
       run:  dotnet pack --configuration Release
 
+#broke around 11/16. No changes on my end and after .net 7 came out. This step fixes it which I don't like as much.
     - name: Prep Auth For NuGet
       run: dotnet nuget add source --username dibiancoj@gmail.com --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/dibiancoj/index.json"
 


### PR DESCRIPTION
The nuget push actions broke randomly. Nothing changed. No expired token and was after the .net 7 release.
This fixes it even though its not as clean as we had.