### PR TITLE
Mongo registration - include logic for localhost with ssh

### DIFF
--- a/Src/LibraryCore.Mongo/LibraryCore.Mongo.csproj
+++ b/Src/LibraryCore.Mongo/LibraryCore.Mongo.csproj
@@ -8,7 +8,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Authors>Jason DiBianco</Authors>
 		<Description>.NetCore Common Library For Mongo and Document Db</Description>
-		<Version>6.0.0</Version>
+		<Version>6.0.1</Version>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>LibraryCore - Mongo</Title>

--- a/Src/LibraryCore.Mongo/Registration/DocumentDbRegistration.cs
+++ b/Src/LibraryCore.Mongo/Registration/DocumentDbRegistration.cs
@@ -1,6 +1,7 @@
 ﻿using MongoDB.Driver;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 
 namespace LibraryCore.Mongo.Registration;
 
@@ -13,7 +14,7 @@ public static class DocumentDbRegistration
     /// For encrypted at rest databases in lambdas
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public static IMongoClient RegisterInLambdaEnvironment(string mongoConnectionString)
+    public static IMongoClient RegisterInLambdaEnvironment(string mongoConnectionString, bool runningFromLocalHostWithSsh = false)
     {
         var settings = MongoClientSettings.FromUrl(new MongoUrl(mongoConnectionString));
 
@@ -26,6 +27,8 @@ public static class DocumentDbRegistration
             }
         };
 
+        settings.AllowInsecureTls = runningFromLocalHostWithSsh;
+
         return new MongoClient(settings);
     }
 
@@ -33,7 +36,7 @@ public static class DocumentDbRegistration
     /// For encrypted at rest databases in ec2, containers, or anything where you can install the certificate
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public static IMongoClient RegisterInWritableEnvironment(string connectionString, StoreName storeToLoad = StoreName.Root, bool allowInsecureTlsForSshIntoAws = false)
+    public static IMongoClient RegisterInWritableEnvironment(string connectionString, StoreName storeToLoad = StoreName.Root, bool runningFromLocalHostWithSsh = false)
     {
         using var localTrustStore = new X509Store(storeToLoad); //isLocalDev ? new X509Store(StoreName.My) : new X509Store(StoreName.Root);
         var certificateCollection = new X509Certificate2Collection();
@@ -44,12 +47,21 @@ public static class DocumentDbRegistration
 
         var settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
 
-        settings.AllowInsecureTls = allowInsecureTlsForSshIntoAws;
+        settings.AllowInsecureTls = runningFromLocalHostWithSsh;
 
         return new MongoClient(settings);
     }
 
-    public static string EncryptedMongoConnectionStringBuilder(string userName, string password, string dbHostName, string readPreference = "primary") =>
-        $"mongodb://{userName}:{password}@{dbHostName}:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference={readPreference}&retryWrites=false";
+    public static string EncryptedMongoConnectionStringBuilder(string userName, string password, string dbHostName, string readPreference = "primary", bool runningFromLocalHostWithSsh = false)
+    {
+        var builder = new StringBuilder($"mongodb://{userName}:{password}@{dbHostName}:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem");
+
+        if (!runningFromLocalHostWithSsh)
+        {
+            builder.Append($"&replicaSet=rs0&readPreference={readPreference}&retryWrites=false");
+        }
+
+        return builder.ToString();
+    }
 
 }

--- a/Tests/LibraryCore.Tests.Mongo/MongoRegistrationTest.cs
+++ b/Tests/LibraryCore.Tests.Mongo/MongoRegistrationTest.cs
@@ -2,20 +2,22 @@
 
 public class MongoRegistrationTest
 {
-    [InlineData("sa", "password456", "mydocdbserver", "primary", "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", "secondary", "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondary&retryWrites=false")]
+    [InlineData("sa", "password456", "mydocdbserver", "primary", false, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
+    [InlineData("root", "password123", "mydocdbserver", "secondary", false, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondary&retryWrites=false")]
+    [InlineData("root", "password123", "mydocdbserver", "secondary", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem")]
     [Theory]
-    public void ConnectionString(string userName, string password, string hostName, string readPreference, string expectedConnectionString)
+    public void ConnectionString(string userName, string password, string hostName, string readPreference, bool fromLocalHostWithSsh, string expectedConnectionString)
     {
-        Assert.Equal(expectedConnectionString, LibraryCore.Mongo.Registration.DocumentDbRegistration.EncryptedMongoConnectionStringBuilder(userName, password, hostName, readPreference: readPreference));
+        Assert.Equal(expectedConnectionString, LibraryCore.Mongo.Registration.DocumentDbRegistration.EncryptedMongoConnectionStringBuilder(userName, password, hostName, readPreference: readPreference, runningFromLocalHostWithSsh: fromLocalHostWithSsh));
     }
 
-    [InlineData("sa", "password456", "mydocdbserver", "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
+    [InlineData("sa", "password456", "mydocdbserver", false, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
+    [InlineData("root", "password123", "mydocdbserver", false, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
+    [InlineData("root", "password123", "mydocdbserver", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem")]
     [Theory]
-    public void ConnectionStringWithDefaultValue(string userName, string password, string hostName, string expectedConnectionString)
+    public void ConnectionStringWithDefaultValue(string userName, string password, string hostName, bool fromLocalHostWithSsh, string expectedConnectionString)
     {
-        Assert.Equal(expectedConnectionString, LibraryCore.Mongo.Registration.DocumentDbRegistration.EncryptedMongoConnectionStringBuilder(userName, password, hostName));
+        Assert.Equal(expectedConnectionString, LibraryCore.Mongo.Registration.DocumentDbRegistration.EncryptedMongoConnectionStringBuilder(userName, password, hostName, runningFromLocalHostWithSsh: fromLocalHostWithSsh));
     }
 
 }


### PR DESCRIPTION
Mongo registration - include logic for localhost with ssh. This way we can get up and running with shared code when we are ssh'ing an ec2/docdb