### PR TITLE
Mongo don't need to specify cert in connection string when ssh'ing in…

### DIFF
--- a/Src/LibraryCore.Mongo/LibraryCore.Mongo.csproj
+++ b/Src/LibraryCore.Mongo/LibraryCore.Mongo.csproj
@@ -8,7 +8,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Authors>Jason DiBianco</Authors>
 		<Description>.NetCore Common Library For Mongo and Document Db</Description>
-		<Version>6.0.1</Version>
+		<Version>6.0.2</Version>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>LibraryCore - Mongo</Title>

--- a/Src/LibraryCore.Mongo/Registration/DocumentDbRegistration.cs
+++ b/Src/LibraryCore.Mongo/Registration/DocumentDbRegistration.cs
@@ -57,11 +57,11 @@ public static class DocumentDbRegistration
 
     public static string EncryptedMongoConnectionStringBuilder(string userName, string password, string dbHostName, string readPreference = "primary", bool runningFromLocalHostWithSsh = false)
     {
-        var builder = new StringBuilder($"mongodb://{userName}:{password}@{dbHostName}:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem");
+        var builder = new StringBuilder($"mongodb://{userName}:{password}@{dbHostName}:27017/?ssl=true");
 
         if (!runningFromLocalHostWithSsh)
         {
-            builder.Append($"&replicaSet=rs0&readPreference={readPreference}&retryWrites=false");
+            builder.Append($"&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference={readPreference}&retryWrites=false");
         }
 
         return builder.ToString();

--- a/Tests/LibraryCore.Tests.Mongo/MongoRegistrationTest.cs
+++ b/Tests/LibraryCore.Tests.Mongo/MongoRegistrationTest.cs
@@ -4,7 +4,7 @@ public class MongoRegistrationTest
 {
     [InlineData("sa", "password456", "mydocdbserver", "primary", false, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
     [InlineData("root", "password123", "mydocdbserver", "secondary", false, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", "secondary", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem")]
+    [InlineData("root", "password123", "mydocdbserver", "secondary", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true")]
     [Theory]
     public void ConnectionString(string userName, string password, string hostName, string readPreference, bool fromLocalHostWithSsh, string expectedConnectionString)
     {
@@ -13,7 +13,7 @@ public class MongoRegistrationTest
 
     [InlineData("sa", "password456", "mydocdbserver", false, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
     [InlineData("root", "password123", "mydocdbserver", false, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem")]
+    [InlineData("root", "password123", "mydocdbserver", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true")]
     [Theory]
     public void ConnectionStringWithDefaultValue(string userName, string password, string hostName, bool fromLocalHostWithSsh, string expectedConnectionString)
     {


### PR DESCRIPTION
Mongo don't need to specify cert in connection string when ssh'ing into ec2.
Doesn't cause any issues but not needed. Removed when not needed in this version.