### PR TITLE
ApiClient - token async shouldn't return a nullable model. It will always be filled

### DIFF
--- a/Src/LibraryCore.ApiClient/ExtensionMethods/HttpClientExtensionMethods.cs
+++ b/Src/LibraryCore.ApiClient/ExtensionMethods/HttpClientExtensionMethods.cs
@@ -25,7 +25,7 @@ public static class HttpClientExtensionMethods
         return httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
     }
 
-    public static async Task<Token?> TokenAsync(this HttpClient httpClient, Uri tokenUri, string clientId, string clientSecret, string grantType = "client_credentials", string scope = "Read", CancellationToken cancellationToken = default)
+    public static async Task<Token> TokenAsync(this HttpClient httpClient, Uri tokenUri, string clientId, string clientSecret, string grantType = "client_credentials", string scope = "Read", CancellationToken cancellationToken = default)
     {
         var rawResponse = await httpClient.PostAsync(tokenUri.AbsoluteUri, new FormUrlEncodedContent(new KeyValuePair<string, string>[]
         {
@@ -35,7 +35,7 @@ public static class HttpClientExtensionMethods
             new("scope", scope),
         }), cancellationToken).ConfigureAwait(false);
 
-        return await rawResponse.EnsureSuccessStatusCode().Content.ReadFromJsonAsync<Token>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await rawResponse.EnsureSuccessStatusCode().Content.ReadFromJsonAsync<Token>(cancellationToken: cancellationToken).ConfigureAwait(false) ?? throw new Exception("Can't Deserialize Token");
     }
 
     /// <summary>

--- a/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
+++ b/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
@@ -11,7 +11,7 @@
 		<Description>Distributed Session State Library</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>6.0.1</Version>
+		<Version>6.0.2</Version>
 		<Title>LibraryCore - Api Client</Title>
 	</PropertyGroup>
 


### PR DESCRIPTION
ApiClient - token async shouldn't return a nullable model. It will always be filled