### PR TITLE
Kafka: Use a thread runner and allow multiple nodes per hosted service

### DIFF
--- a/IntegrationTests/Framework/LibraryCore.IntegrationTests.Framework.Kafka/MyIntegrationHostedAgent.cs
+++ b/IntegrationTests/Framework/LibraryCore.IntegrationTests.Framework.Kafka/MyIntegrationHostedAgent.cs
@@ -20,6 +20,7 @@ public class MyIntegrationHostedAgent : IKafkaProcessor<string, KafkaMessageMode
     public IConsumer<string, KafkaMessageModel> KafkaConsumer { get; }
     private MyIntegrationHostedAgentMockDatabase MyIntegrationHostedAgentMockDatabase { get; }
     public IEnumerable<string> TopicsToRead { get; }
+    public int NodeCount => 5;
 
     public async Task ProcessMessageAsync(ConsumeResult<string, KafkaMessageModel> messageResult, int nodeId, CancellationToken stoppingToken)
     {

--- a/IntegrationTests/Framework/LibraryCore.IntegrationTests.Framework.Kafka/Program.cs
+++ b/IntegrationTests/Framework/LibraryCore.IntegrationTests.Framework.Kafka/Program.cs
@@ -19,15 +19,14 @@ const int numberOfNodesOrPartitions = 5;
 //if you need multiple hosted agents running (with the same class) - this way you end up with 2 runners (i reader isn't enough to keep up). This is needed for kafka to save the correct order (multiple consumers).
 //** not using AddHostedAgent because it doesn't allow you to register the same class twice. So this AddSingleton<IHostedService> is a work around that I found.
 //The key to this is you set the NumPartitions = 2...so we can go between different consumers
+//if you only have 1 hosted agent - just use the normal syntax 'builder.Services.AddHostedService'
 builder.Services.AddSingleton<IHostedService>(sp => new KafkaConsumerService<string, KafkaMessageModel>(sp.GetRequiredService<ILogger<KafkaConsumerService<string, KafkaMessageModel>>>(),
-                                                                                                   new MyIntegrationHostedAgent(KafkaRegistration.BuildConsumerGroup(consumerGroupToUse),
-                                                                                                   sp.GetRequiredService<MyIntegrationHostedAgentMockDatabase>()),
-                                                                                                   numberOfNodesOrPartitions));
+                                                                                                        new MyIntegrationHostedAgent(KafkaRegistration.BuildConsumerGroup(consumerGroupToUse),
+                                                                                                        sp.GetRequiredService<MyIntegrationHostedAgentMockDatabase>())));
 
 //builder.Services.AddSingleton<IHostedService>(sp => new KafkaConsumerService<string, KafkaMessageModel>(sp.GetRequiredService<ILogger<KafkaConsumerService<string, KafkaMessageModel>>>(),
 //                                                                                                   new MyIntegrationHostedAgent(KafkaRegistration.BuildConsumerGroup(consumerGroupToUse),
-//                                                                                                   sp.GetRequiredService<MyIntegrationHostedAgentMockDatabase>()),
-//                                                                                                   2));
+//                                                                                                   sp.GetRequiredService<MyIntegrationHostedAgentMockDatabase>())));
 
 var app = builder.Build();
 
@@ -51,7 +50,8 @@ catch (Exception ex)
 
 try
 {
-    await adminClient.CreateTopicsAsync(new List<TopicSpecification> { new() { Name = KafkaRegistration.TopicsToUse.Single(), NumPartitions = numberOfNodesOrPartitions } });
+    //add 10 just to make sure we have ample slots when the old test hasn't been killed off yet.
+    await adminClient.CreateTopicsAsync(new List<TopicSpecification> { new() { Name = KafkaRegistration.TopicsToUse.Single(), NumPartitions = numberOfNodesOrPartitions + 10 } });
 }
 catch (Exception ex)
 {

--- a/IntegrationTests/LibraryCore.IntegrationTests.Kafka/Fixtures/WebApplicationFactoryFixture.cs
+++ b/IntegrationTests/LibraryCore.IntegrationTests.Kafka/Fixtures/WebApplicationFactoryFixture.cs
@@ -19,7 +19,7 @@ public class WebApplicationFactoryFixture : IDisposable
     }
 
 #if DEBUG
-    public const string SkipReason = "";
+    public const string SkipReason = "Don't want to run Kafka tests locally";
 #else
     public const string SkipReason = "";
 #endif

--- a/IntegrationTests/LibraryCore.IntegrationTests.Kafka/Fixtures/WebApplicationFactoryFixture.cs
+++ b/IntegrationTests/LibraryCore.IntegrationTests.Kafka/Fixtures/WebApplicationFactoryFixture.cs
@@ -19,7 +19,7 @@ public class WebApplicationFactoryFixture : IDisposable
     }
 
 #if DEBUG
-    public const string SkipReason = "Don't want to run kafka integration tests locally";
+    public const string SkipReason = "";
 #else
     public const string SkipReason = "";
 #endif

--- a/IntegrationTests/LibraryCore.IntegrationTests.Kafka/KafkaIntegrationTest.cs
+++ b/IntegrationTests/LibraryCore.IntegrationTests.Kafka/KafkaIntegrationTest.cs
@@ -52,7 +52,7 @@ public class KafkaIntegrationTest : IClassFixture<WebApplicationFactoryFixture>
         Assert.Equal(howManyRecordsToInsert, recordsFound.Count());
 
         //this should be spread out round robin. If this fails its not an "error"...but should be looked into why its not spreading the messages out
-        Assert.Equal(2, recordsFound.GroupBy(x => x.NodeId).Count());
+        Assert.True(recordsFound.GroupBy(x => x.NodeId).Count() > 2);
 
         //make sure we have the right messages
         foreach (var toPublish in messagesToPublish)

--- a/IntegrationTests/LibraryCore.IntegrationTests.Kafka/KafkaIntegrationTest.cs
+++ b/IntegrationTests/LibraryCore.IntegrationTests.Kafka/KafkaIntegrationTest.cs
@@ -61,8 +61,8 @@ public class KafkaIntegrationTest : IClassFixture<WebApplicationFactoryFixture>
             Assert.Contains(recordsFound, x => x.Topic == toPublish.Topic && x.TestId == testId && x.KeyId == toPublish.KeyId && x.Message == toPublish.Message);
         }
 
-        //now make sure after hanging out for 20 seconds that it succeeds
-        await Task.Delay(TimeSpan.FromSeconds(30));
+        //let it hang out for a few seconds to ensure the threads keep going and processes more.
+        await Task.Delay(TimeSpan.FromSeconds(15));
 
         var newTestId = Guid.NewGuid();
 

--- a/Src/LibraryCore.Kafka/IKafkaProcessor.cs
+++ b/Src/LibraryCore.Kafka/IKafkaProcessor.cs
@@ -7,5 +7,6 @@ public interface IKafkaProcessor<TKafkaKey, TKafkaMessageBody>
     public IConsumer<TKafkaKey, TKafkaMessageBody> KafkaConsumer { get; }
     public IEnumerable<string> TopicsToRead { get; }
     public TimeSpan KafkaConsumeTimeOut() => new(0, 0, 15);
+    public int NodeCount => 1;
     public Task ProcessMessageAsync(ConsumeResult<TKafkaKey, TKafkaMessageBody> messageResult, int nodeId, CancellationToken stoppingToken);
 }

--- a/Src/LibraryCore.Kafka/IKafkaProcessor.cs
+++ b/Src/LibraryCore.Kafka/IKafkaProcessor.cs
@@ -7,6 +7,6 @@ public interface IKafkaProcessor<TKafkaKey, TKafkaMessageBody>
     public IConsumer<TKafkaKey, TKafkaMessageBody> KafkaConsumer { get; }
     public IEnumerable<string> TopicsToRead { get; }
     public TimeSpan KafkaConsumeTimeOut() => new(0, 0, 15);
-    public int NodeCount => 1;
+    public int NodeCount { get; }
     public Task ProcessMessageAsync(ConsumeResult<TKafkaKey, TKafkaMessageBody> messageResult, int nodeId, CancellationToken stoppingToken);
 }

--- a/Src/LibraryCore.Kafka/KafkaConsumerService.cs
+++ b/Src/LibraryCore.Kafka/KafkaConsumerService.cs
@@ -1,8 +1,5 @@
-﻿using Confluent.Kafka;
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.Runtime.CompilerServices;
-using System.Threading.Channels;
 
 namespace LibraryCore.Kafka;
 
@@ -12,122 +9,26 @@ namespace LibraryCore.Kafka;
 //builder.Services.AddSingleton<BackgroundService>(x => new MyHostedAgent());
 public class KafkaConsumerService<TKafkaKey, TKafkaMessageBody> : BackgroundService
 {
-    public KafkaConsumerService(ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> logger, IKafkaProcessor<TKafkaKey, TKafkaMessageBody> kafkaProcessor, int nodeId = 1)
+    public KafkaConsumerService(ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> logger, IKafkaProcessor<TKafkaKey, TKafkaMessageBody> kafkaProcessor, int numberOfNodes = 1)
     {
         Logger = logger;
         KafkaProcessor = kafkaProcessor;
-        NodeId = nodeId;
-        KafkaConsumeTimeOut = kafkaProcessor.KafkaConsumeTimeOut();
+        NumberOfNodes = numberOfNodes;
     }
 
     private ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> Logger { get; }
     private IKafkaProcessor<TKafkaKey, TKafkaMessageBody> KafkaProcessor { get; }
-    public int NodeId { get; }
-    private TimeSpan KafkaConsumeTimeOut { get; }
+    public int NumberOfNodes { get; }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        //background services doesn't raise exceptions based on the github issues. It uses a fire and forget. Don't have a solution other then to log it
-        var channel = Channel.CreateUnbounded<ConsumeResult<TKafkaKey, TKafkaMessageBody>?>(new UnboundedChannelOptions
+        var tasks = new List<Task>();
+
+        for (int i = 0; i < NumberOfNodes; i++)
         {
-            SingleReader = true,
-            SingleWriter = true
-        });
-
-        var reader = ReadAndProcessMessageAsync(channel.Reader, stoppingToken);
-        var consumeAndPublishChannel = PublishIncomingMessageAsync(channel.Writer, stoppingToken);
-
-        await Task.WhenAll(consumeAndPublishChannel, reader);
-    }
-
-    private async Task PublishIncomingMessageAsync(ChannelWriter<ConsumeResult<TKafkaKey, TKafkaMessageBody>?> channelWriter, CancellationToken stoppingToken)
-    {
-        Logger.LogInformation(LogMessage("Started", string.Join(',', KafkaProcessor.TopicsToRead)));
-
-        //let the other part of the hosted service bootup
-        await Task.Delay(100, stoppingToken);
-
-        try
-        {
-            KafkaProcessor.KafkaConsumer.Subscribe(KafkaProcessor.TopicsToRead);
-
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                var consumeResult = KafkaProcessor.KafkaConsumer.Consume(KafkaConsumeTimeOut);
-
-                //only publish if it didn't time out and we have an entry from kafka. This is an effort to keep the channel clear
-                if (consumeResult != null)
-                {
-                    Logger.LogInformation(LogMessage("Kafka Messaged Received", $"Key={consumeResult.Message.Key ?? default}"));
-
-                    //we have a message so go publish. (would be null if it timed out)
-                    await channelWriter.WriteAsync(consumeResult, stoppingToken).ConfigureAwait(false);
-                }
-
-                //allow threads to get control. We need something that is async to allow threads to continue and run anything needed that is urgent (mainly for time out scenario)
-                await Task.Delay(10, stoppingToken).ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
-        {
-            if (LogExceptionAndThrow(ex, stoppingToken))
-            {
-                throw;
-            }
-        }
-    }
-
-    private async Task ReadAndProcessMessageAsync(ChannelReader<ConsumeResult<TKafkaKey, TKafkaMessageBody>?> channelReader, CancellationToken stoppingToken)
-    {
-        Logger.LogInformation(LogMessage("Started"));
-
-        //let the other part of the hosted service bootup
-        await Task.Delay(100, stoppingToken).ConfigureAwait(false);
-
-        try
-        {
-            while (await channelReader.WaitToReadAsync(cancellationToken: stoppingToken).ConfigureAwait(false))
-            {
-                while (channelReader.TryRead(out var kafkaMessageResult) && kafkaMessageResult != null)
-                {
-                    Logger.LogInformation(LogMessage("Channel Message Received", $"Key={kafkaMessageResult.Message.Key ?? default}"));
-
-                    await KafkaProcessor.ProcessMessageAsync(kafkaMessageResult, NodeId, stoppingToken).ConfigureAwait(false);
-
-                    KafkaProcessor.KafkaConsumer.StoreOffset(kafkaMessageResult);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            if (LogExceptionAndThrow(ex, stoppingToken))
-            {
-                throw;
-            }
-        }
-    }
-
-    private string LogMessage(string command, string? additionalInfo = null, [CallerMemberName] string methodName = "")
-    {
-        string? additionalInfoOutput = additionalInfo == null ?
-                                        null :
-                                        $"({additionalInfo})";
-
-        return $"{command} : Node = {NodeId} : Method = {methodName}{additionalInfoOutput} : {DateTime.Now}";
-    }
-
-    private bool LogExceptionAndThrow(Exception ex, CancellationToken cancellationToken, [CallerMemberName] string methodName = "")
-    {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            Logger.LogWarning(LogMessage("Cancellation Token Is Stopping", methodName: methodName));
-            return false;
+            tasks.Add(new KafkaThreadRunner<TKafkaKey, TKafkaMessageBody>(i + 1, Logger, KafkaProcessor).CreateThreadAsync(stoppingToken));
         }
 
-        //log any critical errors. Hosted services don't bubble up well with threading like this.
-        Logger.LogCritical(ex, LogMessage("Error In Kafka Hosted Service. Service is not unstable", methodName: methodName));
-
-        return true;
+        await Task.WhenAll(tasks);
     }
-
 }

--- a/Src/LibraryCore.Kafka/KafkaNodeRunner.cs
+++ b/Src/LibraryCore.Kafka/KafkaNodeRunner.cs
@@ -5,9 +5,9 @@ using System.Threading.Channels;
 
 namespace LibraryCore.Kafka;
 
-internal class KafkaThreadRunner<TKafkaKey, TKafkaMessageBody>
+internal class KafkaNodeRunner<TKafkaKey, TKafkaMessageBody>
 {
-    internal KafkaThreadRunner(int nodeId, ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> logger, IKafkaProcessor<TKafkaKey, TKafkaMessageBody> kafkaProcessor)
+    internal KafkaNodeRunner(int nodeId, ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> logger, IKafkaProcessor<TKafkaKey, TKafkaMessageBody> kafkaProcessor)
     {
         NodeId = nodeId;
         Logger = logger;
@@ -18,7 +18,7 @@ internal class KafkaThreadRunner<TKafkaKey, TKafkaMessageBody>
     private ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> Logger { get; }
     private IKafkaProcessor<TKafkaKey, TKafkaMessageBody> KafkaProcessor { get; }
 
-    internal async Task CreateThreadAsync(CancellationToken cancellationToken)
+    internal async Task CreateNodeAsync(CancellationToken cancellationToken)
     {
         var channel = Channel.CreateUnbounded<ConsumeResult<TKafkaKey, TKafkaMessageBody>?>(new UnboundedChannelOptions
         {

--- a/Src/LibraryCore.Kafka/KafkaThreadRunner.cs
+++ b/Src/LibraryCore.Kafka/KafkaThreadRunner.cs
@@ -1,0 +1,126 @@
+﻿using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace LibraryCore.Kafka;
+
+internal class KafkaThreadRunner<TKafkaKey, TKafkaMessageBody>
+{
+    internal KafkaThreadRunner(int nodeId, ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> logger, IKafkaProcessor<TKafkaKey, TKafkaMessageBody> kafkaProcessor)
+    {
+        NodeId = nodeId;
+        Logger = logger;
+        KafkaProcessor = kafkaProcessor;
+    }
+
+    private int NodeId { get; }
+    private ILogger<KafkaConsumerService<TKafkaKey, TKafkaMessageBody>> Logger { get; }
+    private IKafkaProcessor<TKafkaKey, TKafkaMessageBody> KafkaProcessor { get; }
+
+    internal async Task CreateThreadAsync(CancellationToken cancellationToken)
+    {
+        var channel = Channel.CreateUnbounded<ConsumeResult<TKafkaKey, TKafkaMessageBody>?>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = true
+        });
+
+        var reader = ReadAndProcessMessageAsync(channel.Reader, cancellationToken);
+        var consumeAndPublishChannel = PublishIncomingMessageAsync(channel.Writer, cancellationToken);
+
+        await Task.WhenAll(reader, consumeAndPublishChannel);
+    }
+
+    private async Task PublishIncomingMessageAsync(ChannelWriter<ConsumeResult<TKafkaKey, TKafkaMessageBody>?> channelWriter, CancellationToken stoppingToken)
+    {
+        var timeout = KafkaProcessor.KafkaConsumeTimeOut();
+
+        Logger.LogInformation(LogMessage("Started", string.Join(',', KafkaProcessor.TopicsToRead)));
+
+        //let the other part of the hosted service bootup
+        await Task.Delay(100, stoppingToken);
+
+        try
+        {
+            KafkaProcessor.KafkaConsumer.Subscribe(KafkaProcessor.TopicsToRead);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var consumeResult = KafkaProcessor.KafkaConsumer.Consume(timeout);
+
+                //only publish if it didn't time out and we have an entry from kafka. This is an effort to keep the channel clear
+                if (consumeResult != null)
+                {
+                    Logger.LogInformation(LogMessage("Kafka Messaged Received", $"Key={consumeResult.Message.Key ?? default}"));
+
+                    //we have a message so go publish. (would be null if it timed out)
+                    await channelWriter.WriteAsync(consumeResult, stoppingToken).ConfigureAwait(false);
+                }
+
+                //allow threads to get control. We need something that is async to allow threads to continue and run anything needed that is urgent (mainly for time out scenario)
+                await Task.Delay(10, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            if (LogExceptionAndThrow(ex, stoppingToken))
+            {
+                throw;
+            }
+        }
+    }
+
+    private async Task ReadAndProcessMessageAsync(ChannelReader<ConsumeResult<TKafkaKey, TKafkaMessageBody>?> channelReader, CancellationToken stoppingToken)
+    {
+        Logger.LogInformation(LogMessage("Started"));
+
+        //let the other part of the hosted service bootup
+        await Task.Delay(100, stoppingToken).ConfigureAwait(false);
+
+        try
+        {
+            while (await channelReader.WaitToReadAsync(cancellationToken: stoppingToken).ConfigureAwait(false))
+            {
+                while (channelReader.TryRead(out var kafkaMessageResult) && kafkaMessageResult != null)
+                {
+                    Logger.LogInformation(LogMessage("Channel Message Received", $"Key={kafkaMessageResult.Message.Key ?? default}"));
+
+                    await KafkaProcessor.ProcessMessageAsync(kafkaMessageResult, NodeId, stoppingToken).ConfigureAwait(false);
+
+                    KafkaProcessor.KafkaConsumer.StoreOffset(kafkaMessageResult);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            if (LogExceptionAndThrow(ex, stoppingToken))
+            {
+                throw;
+            }
+        }
+    }
+
+    private string LogMessage(string command, string? additionalInfo = null, [CallerMemberName] string methodName = "")
+    {
+        string? additionalInfoOutput = additionalInfo == null ?
+                                        null :
+                                        $"({additionalInfo})";
+
+        return $"{command} : Node = {NodeId} : Method = {methodName}{additionalInfoOutput} : {DateTime.Now}";
+    }
+
+    private bool LogExceptionAndThrow(Exception ex, CancellationToken cancellationToken, [CallerMemberName] string methodName = "")
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            Logger.LogWarning(LogMessage("Cancellation Token Is Stopping", methodName: methodName));
+            return false;
+        }
+
+        //log any critical errors. Hosted services don't bubble up well with threading like this.
+        Logger.LogCritical(ex, LogMessage("Error In Kafka Hosted Service. Service is not unstable", methodName: methodName));
+
+        return true;
+    }
+}

--- a/Src/LibraryCore.Kafka/LibraryCore.Kafka.csproj
+++ b/Src/LibraryCore.Kafka/LibraryCore.Kafka.csproj
@@ -11,7 +11,7 @@
 		<Description>.NetCore Kafka Logic With Consumer Patterns</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>6.0.0</Version>
+		<Version>6.1.0</Version>
 		<Title>LibraryCore - Kafka</Title>
 	</PropertyGroup>
 

--- a/Tests/LibraryCore.Tests.Kafka/Framework/MyUnitTestHostedAgent.cs
+++ b/Tests/LibraryCore.Tests.Kafka/Framework/MyUnitTestHostedAgent.cs
@@ -13,7 +13,7 @@ public class MyUnitTestHostedAgent : IKafkaProcessor<string, string>
         KafkaConsumer = consumer;
         MessagesProcessed = new ConcurrentBag<ProcessedItem>();
         TopicsToRead = new[] { "Topic1", "Topic2" };
-        NodeCount = howManyNodesSetup.HowManyNodes;
+        NodeCount = howManyNodesSetup.HowManyNodes; //this is only here so we can mock it. Real use would pass in IOptions or this would be hardcoded.
     }
 
     public ConcurrentBag<ProcessedItem> MessagesProcessed { get; }

--- a/Tests/LibraryCore.Tests.Kafka/Framework/MyUnitTestHostedAgent.cs
+++ b/Tests/LibraryCore.Tests.Kafka/Framework/MyUnitTestHostedAgent.cs
@@ -8,11 +8,12 @@ namespace LibraryCore.Tests.Kafka.Framework;
 [ExcludeFromCodeCoverage(Justification = "Coming up in code coverage report as actual code.")]
 public class MyUnitTestHostedAgent : IKafkaProcessor<string, string>
 {
-    public MyUnitTestHostedAgent(IConsumer<string, string> consumer)
+    public MyUnitTestHostedAgent(IConsumer<string, string> consumer, HowManyNodesSetup howManyNodesSetup)
     {
         KafkaConsumer = consumer;
         MessagesProcessed = new ConcurrentBag<ProcessedItem>();
         TopicsToRead = new[] { "Topic1", "Topic2" };
+        NodeCount = howManyNodesSetup.HowManyNodes;
     }
 
     public ConcurrentBag<ProcessedItem> MessagesProcessed { get; }
@@ -20,6 +21,8 @@ public class MyUnitTestHostedAgent : IKafkaProcessor<string, string>
     public IConsumer<string, string> KafkaConsumer { get; }
 
     public IEnumerable<string> TopicsToRead { get; }
+
+    public int NodeCount { get; }
 
     public async Task ProcessMessageAsync(ConsumeResult<string, string> messageResult, int nodeId, CancellationToken stoppingToken)
     {
@@ -30,4 +33,14 @@ public class MyUnitTestHostedAgent : IKafkaProcessor<string, string>
     }
 
     public record ProcessedItem(string Topic, int NodeId, Message<string, string> Message);
+
+    public class HowManyNodesSetup
+    {
+        public HowManyNodesSetup(int howManyNodes)
+        {
+            HowManyNodes = howManyNodes;
+        }
+
+        public int HowManyNodes { get; }
+    }
 }


### PR DESCRIPTION
Kafka: Use a thread runner and allow multiple nodes per hosted service. Changes approach from multiple hosted services to 1 that can expand as needed.