### PR TITLE
Build: update checkout to use v3 to remove node warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET 7.x
       uses: actions/setup-dotnet@v1
       with:
@@ -59,7 +59,7 @@ jobs:
         os: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup .NET 7.x
       uses: actions/setup-dotnet@v1
@@ -99,7 +99,7 @@ jobs:
     needs: [test-and-build, integration-tests]
     if: github.ref == 'refs/heads/master'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET 7.x
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.x
 
     - name: Setup .NET 6.x
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.x
 
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup .NET 7.x
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.x
 
@@ -102,12 +102,12 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.x
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.x
 


### PR DESCRIPTION
Build: update checkout to use v3 to remove node warning