### PR TITLE
Mongo: Add optional parameter for write retries (doc db)

### DIFF
--- a/Src/LibraryCore.Mongo/LibraryCore.Mongo.csproj
+++ b/Src/LibraryCore.Mongo/LibraryCore.Mongo.csproj
@@ -8,7 +8,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Authors>Jason DiBianco</Authors>
 		<Description>.NetCore Common Library For Mongo and Document Db</Description>
-		<Version>6.2.0</Version>
+		<Version>6.2.1</Version>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>LibraryCore - Mongo</Title>

--- a/Src/LibraryCore.Mongo/Registration/DocumentDbRegistration.cs
+++ b/Src/LibraryCore.Mongo/Registration/DocumentDbRegistration.cs
@@ -55,13 +55,14 @@ public static class DocumentDbRegistration
         return new MongoClient(settings);
     }
 
-    public static string EncryptedMongoConnectionStringBuilder(string userName, string password, string dbHostName, string readPreference = "primary", bool runningFromLocalHostWithSsh = false, int port = 27017)
+    //retry writes aren't supported in document db. Always have that false unless your using the real mongo
+    public static string EncryptedMongoConnectionStringBuilder(string userName, string password, string dbHostName, string readPreference = "primary", bool runningFromLocalHostWithSsh = false, int port = 27017, bool retryWrites = false)
     {
-        var builder = new StringBuilder($"mongodb://{userName}:{password}@{dbHostName}:{port}/?ssl=true");
+        var builder = new StringBuilder($"mongodb://{userName}:{password}@{dbHostName}:{port}/?ssl=true&retryWrites=false");
 
         if (!runningFromLocalHostWithSsh)
         {
-            builder.Append($"&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference={readPreference}&retryWrites=false");
+            builder.Append($"&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference={readPreference}");
         }
 
         return builder.ToString();

--- a/Tests/LibraryCore.Tests.Mongo/MongoRegistrationTest.cs
+++ b/Tests/LibraryCore.Tests.Mongo/MongoRegistrationTest.cs
@@ -2,19 +2,19 @@
 
 public class MongoRegistrationTest
 {
-    [InlineData("sa", "password456", "mydocdbserver", "primary", false, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", "secondary", false, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", "secondary", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true")]
+    [InlineData("sa", "password456", "mydocdbserver", "primary", false, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&retryWrites=false&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary")]
+    [InlineData("root", "password123", "mydocdbserver", "secondary", false, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&retryWrites=false&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondary")]
+    [InlineData("root", "password123", "mydocdbserver", "secondary", true, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&retryWrites=false")]
     [Theory]
     public void ConnectionString(string userName, string password, string hostName, string readPreference, bool fromLocalHostWithSsh, string expectedConnectionString)
     {
         Assert.Equal(expectedConnectionString, LibraryCore.Mongo.Registration.DocumentDbRegistration.EncryptedMongoConnectionStringBuilder(userName, password, hostName, readPreference: readPreference, runningFromLocalHostWithSsh: fromLocalHostWithSsh));
     }
 
-    [InlineData("sa", "password456", "mydocdbserver", false, 27017, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", false, 27017, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", false, 9999, "mongodb://root:password123@mydocdbserver:9999/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary&retryWrites=false")]
-    [InlineData("root", "password123", "mydocdbserver", true, 27017, "mongodb://root:password123@mydocdbserver:27017/?ssl=true")]
+    [InlineData("sa", "password456", "mydocdbserver", false, 27017, "mongodb://sa:password456@mydocdbserver:27017/?ssl=true&retryWrites=false&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary")]
+    [InlineData("root", "password123", "mydocdbserver", false, 27017, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&retryWrites=false&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary")]
+    [InlineData("root", "password123", "mydocdbserver", false, 9999, "mongodb://root:password123@mydocdbserver:9999/?ssl=true&retryWrites=false&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=primary")]
+    [InlineData("root", "password123", "mydocdbserver", true, 27017, "mongodb://root:password123@mydocdbserver:27017/?ssl=true&retryWrites=false")]
     [Theory]
     public void ConnectionStringWithDefaultValue(string userName, string password, string hostName, bool fromLocalHostWithSsh, int hostPort, string expectedConnectionString)
     {


### PR DESCRIPTION
Mongo: Add optional parameter for write retries (doc db). This isn't supported in document db.