### PR TITLE
Api Project Update and Nuget Updates

### DIFF
--- a/IntegrationTests/LibraryCore.IntegrationTests.Kafka/LibraryCore.IntegrationTests.Kafka.csproj
+++ b/IntegrationTests/LibraryCore.IntegrationTests.Kafka/LibraryCore.IntegrationTests.Kafka.csproj
@@ -33,7 +33,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/IntegrationTests/LibraryCore.IntegrationTests.Mongo/LibraryCore.IntegrationTests.Mongo.csproj
+++ b/IntegrationTests/LibraryCore.IntegrationTests.Mongo/LibraryCore.IntegrationTests.Mongo.csproj
@@ -33,7 +33,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/IntegrationTests/LibraryCore.IntegrationTests/FluentHttpRequestIntegrationTest.cs
+++ b/IntegrationTests/LibraryCore.IntegrationTests/FluentHttpRequestIntegrationTest.cs
@@ -2,6 +2,7 @@
 using LibraryCore.ApiClient.ExtensionMethods;
 using LibraryCore.IntegrationTests.Fixtures;
 using System.Net.Http.Json;
+using System.Text.Json;
 using static LibraryCore.ApiClient.ContentTypeLookup;
 
 namespace LibraryCore.IntegrationTests;
@@ -78,7 +79,7 @@ public class FluentHttpRequestIntegrationTest : IClassFixture<WebApplicationFact
     public async Task QueryStringsTest()
     {
         var response = await WebApplicationFactoryFixture.HttpClientToUse.SendAsync(new FluentRequest(HttpMethod.Get, "FluentHttpRequest/QueryStringTest")
-                                                                                        .AddQueryStrings(new Dictionary<string,string>
+                                                                                        .AddQueryStrings(new Dictionary<string, string>
                                                                                         {
                                                                                             { "Q1", "One" },
                                                                                             { "Q2", "Two" }
@@ -122,6 +123,26 @@ public class FluentHttpRequestIntegrationTest : IClassFixture<WebApplicationFact
                                                                                         {
                                                                                             Id = 5,
                                                                                             Text = "5"
+                                                                                        }));
+
+        var result = await response.EnsureSuccessStatusCode()
+                                .Content.ReadFromJsonAsync<ResultModel>() ?? throw new Exception("Can't deserialize result");
+
+        Assert.Equal(6, result.Id);
+        Assert.Equal("5_Result", result.Text);
+    }
+
+    [Fact]
+    public async Task SimpleJsonPayloadWithJsonOptions()
+    {
+        var response = await WebApplicationFactoryFixture.HttpClientToUse.SendAsync(new FluentRequest(HttpMethod.Get, "FluentHttpRequest/SimpleJsonPayloadWithJsonParameters")
+                                                                                        .AddJsonBody(new
+                                                                                        {
+                                                                                            id = 5,
+                                                                                            text = "5"
+                                                                                        }, jsonSerializerOptions: new JsonSerializerOptions
+                                                                                        {
+                                                                                            PropertyNameCaseInsensitive = true
                                                                                         }));
 
         var result = await response.EnsureSuccessStatusCode()

--- a/IntegrationTests/LibraryCore.IntegrationTests/LibraryCore.IntegrationTests.csproj
+++ b/IntegrationTests/LibraryCore.IntegrationTests/LibraryCore.IntegrationTests.csproj
@@ -31,14 +31,14 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/LibraryCore.ApiClient/ExtensionMethods/HttpClientExtensionMethods.cs
+++ b/Src/LibraryCore.ApiClient/ExtensionMethods/HttpClientExtensionMethods.cs
@@ -1,16 +1,17 @@
 ﻿using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LibraryCore.ApiClient.ExtensionMethods;
 
 public static class HttpClientExtensionMethods
 {
-    public static async Task<T?> SendRequestToJsonAsync<T>(this HttpClient httpClient, HttpRequestMessage requestMessage, CancellationToken cancellationToken = default)
+    public static async Task<T?> SendRequestToJsonAsync<T>(this HttpClient httpClient, HttpRequestMessage requestMessage, CancellationToken cancellationToken = default, JsonSerializerOptions? jsonSerializerOptions = null)
     {
         var rawResponse = await SendMessageHelper(httpClient, requestMessage, cancellationToken);
 
         return await rawResponse.EnsureSuccessStatusCode()
-                .Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
+                .Content.ReadFromJsonAsync<T>(options: jsonSerializerOptions, cancellationToken: cancellationToken);
     }
 
     public static async Task<T?> SendRequestToXmlAsync<T>(this HttpClient httpClient, HttpRequestMessage requestMessage, CancellationToken cancellationToken = default)

--- a/Src/LibraryCore.ApiClient/FluentRequest.cs
+++ b/Src/LibraryCore.ApiClient/FluentRequest.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 using static LibraryCore.ApiClient.ContentTypeLookup;
 
 namespace LibraryCore.ApiClient;
@@ -81,9 +82,9 @@ public class FluentRequest
         return this;
     }
 
-    public FluentRequest AddJsonBody<T>(T model)
+    public FluentRequest AddJsonBody<T>(T model, JsonSerializerOptions? jsonSerializerOptions = null)
     {
-        Message.Content = JsonContent.Create(model);
+        Message.Content = JsonContent.Create(model, options: jsonSerializerOptions);
         return this;
     }
 
@@ -110,7 +111,7 @@ public class FluentRequest
         Message.Headers.Authorization = new AuthenticationHeaderValue("Basic", BasicAuthenticationHeaderValue(userName, password));
         return this;
     }
-    
+
     public static string BasicAuthenticationHeaderValue(string userName, string password) => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{userName}:{password}"));
 
     /// <summary>

--- a/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
+++ b/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
@@ -11,7 +11,7 @@
 		<Description>Distributed Session State Library</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>6.0.4</Version>
+		<Version>6.1.0</Version>
 		<Title>LibraryCore - Api Client</Title>
 	</PropertyGroup>
 

--- a/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
+++ b/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
@@ -18,6 +18,7 @@
 	<ItemGroup>
 		<PackageReference Include="LibraryCore.XmlSerialization" Version="6.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/Src/LibraryCore.Core/LibraryCore.Core.csproj
+++ b/Src/LibraryCore.Core/LibraryCore.Core.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/LibraryCore.Tests.ApiClient/HttpClientExtensionMethodTest.cs
+++ b/Tests/LibraryCore.Tests.ApiClient/HttpClientExtensionMethodTest.cs
@@ -46,7 +46,7 @@ public class HttpClientExtensionMethodTest
                                                 .AddHeader("Header1", "Header1Value")
                                                 .AddJsonBody(jsonParameters);
 
-        var result = await HttpRequestMockSetup.HttpClientToUse.SendRequestToJsonAsync<IEnumerable<WeatherForecast>>(request, includeCancelToken ? new CancellationToken() : default) ?? throw new Exception("Can't deserialize result");
+        var result = await HttpRequestMockSetup.HttpClientToUse.SendRequestToJsonAsync<IEnumerable<WeatherForecast>>(request, cancellationToken: includeCancelToken ? new CancellationToken() : default) ?? throw new Exception("Can't deserialize result");
 
         Assert.Single(result);
         Assert.Contains(result, x => x.Id == 1 && x.TemperatureF == 10 && x.Summary == "Weather 1");

--- a/Tests/LibraryCore.Tests.Core/LibraryCore.Tests.Core.csproj
+++ b/Tests/LibraryCore.Tests.Core/LibraryCore.Tests.Core.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="MoqProtectedLike" Version="2.0.1" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Api project = Allow to pass in the json serializer options when adding a json body and json payload.
-  Update nuget packages. Minor changes