### PR TITLE
Api - SendRequestToJson with 200 and 400 different models

### DIFF
--- a/Src/LibraryCore.ApiClient/ExtensionMethods/Models/SendRequestToJsonUnionResult.cs
+++ b/Src/LibraryCore.ApiClient/ExtensionMethods/Models/SendRequestToJsonUnionResult.cs
@@ -1,0 +1,41 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace LibraryCore.ApiClient.ExtensionMethods.Models;
+
+public class SendRequestToJsonUnionResult<T1Ok, T2BadRequest>
+{
+    private SendRequestToJsonUnionResult(bool isSuccessful, T1Ok? okResult, T2BadRequest? badRequest)
+    {
+        IsSuccessful = isSuccessful;
+        OkResult = okResult;
+        BadRequest = badRequest;
+    }
+
+    public bool IsSuccessful { get; }
+    private T1Ok? OkResult { get; }
+    private T2BadRequest? BadRequest { get; }
+
+    public static SendRequestToJsonUnionResult<T1Ok, T2BadRequest> CreateSuccess(T1Ok? okResult) =>
+        new(true, okResult, default);
+
+    public static SendRequestToJsonUnionResult<T1Ok, T2BadRequest> CreateBadRequest(T2BadRequest? badRequest) =>
+        new(false, default, badRequest);
+
+    /// <summary>
+    /// Returns true is the call is 200 ok
+    /// </summary>
+    public bool TryGetIsSuccessful([NotNullWhen(true)] out T1Ok? result)
+    {
+        result = OkResult;
+        return IsSuccessful;
+    }
+
+    /// <summary>
+    /// Returns true is the call is 400 bad request
+    /// </summary>
+    public bool TryGetIsBadRequest([NotNullWhen(true)] out T2BadRequest? result)
+    {
+        result = BadRequest;
+        return !IsSuccessful;
+    }
+}

--- a/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
+++ b/Src/LibraryCore.ApiClient/LibraryCore.ApiClient.csproj
@@ -11,7 +11,7 @@
 		<Description>Distributed Session State Library</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>6.1.1</Version>
+		<Version>6.2.0</Version>
 		<Title>LibraryCore - Api Client</Title>
 	</PropertyGroup>
 


### PR DESCRIPTION
Api Project
You can run a json api call and have it return a different model for a 200 and 400. This way you can handle validation with a different model with only 2 lines of code.