### PR TITLE
Memory cache breaking change with the token parameter

### DIFF
--- a/Src/LibraryCore.Caching/InMemoryCacheService.cs
+++ b/Src/LibraryCore.Caching/InMemoryCacheService.cs
@@ -50,11 +50,11 @@ public class InMemoryCacheService(IMemoryCache memoryCache)
     /// <summary>
     /// Create a cache item where you can remove that 'group' from the cache using a cancellation token
     /// </summary>
-    public async ValueTask<TItem> GetOrCreateWithLockAndEvictionAsync<TItem>(object key, Func<ICacheEntry, Task<TItem>> factory, CancellationTokenSource cancellationToken)
+    public async ValueTask<TItem> GetOrCreateWithLockAndEvictionAsync<TItem>(object key, Func<ICacheEntry, Task<TItem>> factory, CancellationToken cancellationToken)
     {
         return await GetOrCreateWithLockAsync(key, async x =>
         {
-            x.AddExpirationToken(new CancellationChangeToken(cancellationToken.Token));
+            x.AddExpirationToken(new CancellationChangeToken(cancellationToken));
 
             return await factory(x);
         });

--- a/Src/LibraryCore.Caching/LibraryCore.Caching.csproj
+++ b/Src/LibraryCore.Caching/LibraryCore.Caching.csproj
@@ -11,7 +11,7 @@
 		<Description>.NetCore Common Utilities For Caching</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>8.0.0</Version>
+		<Version>8.1.0</Version>
 		<Title>LibraryCore - Caching</Title>
 	</PropertyGroup>
 

--- a/Tests/LibraryCore.Tests.Caching/MemoryCacheTest.cs
+++ b/Tests/LibraryCore.Tests.Caching/MemoryCacheTest.cs
@@ -76,37 +76,37 @@ public class MemoryCacheTest
     {
         int key1 = 1;
         int key2 = 2;
-        var cancelToken = new CancellationTokenSource();
+        var cancelTokenSource = new CancellationTokenSource();
 
         async Task<int> factory1(ICacheEntry x) => await Task.FromResult(key1);
         async Task<int> factory2(ICacheEntry x) => await Task.FromResult(key2);
 
         //pull from the cache
-        Assert.Equal(1, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key1", factory1, cancelToken));
-        Assert.Equal(2, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key2", factory2, cancelToken));
+        Assert.Equal(1, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key1", factory1, cancelTokenSource.Token));
+        Assert.Equal(2, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key2", factory2, cancelTokenSource.Token));
 
         key1 = 101;
         key2 = 102;
 
         //should get 1 since it's pulling from the cache
-        Assert.Equal(1, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key1", factory1, cancelToken));
-        Assert.Equal(2, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key2", factory2, cancelToken));
+        Assert.Equal(1, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key1", factory1, cancelTokenSource.Token));
+        Assert.Equal(2, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key2", factory2, cancelTokenSource.Token));
 
         //remove the cache
-        cancelToken.Cancel();
+        cancelTokenSource.Cancel();
 
         //create a new token
-        cancelToken = new CancellationTokenSource();
+        cancelTokenSource = new CancellationTokenSource();
 
         //both entries should be removed...so both should be the new field
-        Assert.Equal(101, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key1", factory1, cancelToken));
-        Assert.Equal(102, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key2", factory2, cancelToken));
+        Assert.Equal(101, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key1", factory1, cancelTokenSource.Token));
+        Assert.Equal(102, await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync("key2", factory2, cancelTokenSource.Token));
 
         //clear it
-        cancelToken.Cancel();
+        cancelTokenSource.Cancel();
 
         //make sure it's not there now
-        Assert.Equal("FromSource", await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync(999, x => Task.FromResult("FromSource"), cancelToken));
+        Assert.Equal("FromSource", await InMemoryCacheServiceToUse.GetOrCreateWithLockAndEvictionAsync(999, x => Task.FromResult("FromSource"), cancelTokenSource.Token));
     }
 
     #endregion


### PR DESCRIPTION
Memory cache breaking change with the token parameter. Will pass in the token instead of the source since the cache needs to react.