### PR TITLE
kafka consumer: don't use an arrow function on the hosted service.

### DIFF
--- a/Src/LibraryCore.Kafka/HostedServices/KafkaConsumerService.cs
+++ b/Src/LibraryCore.Kafka/HostedServices/KafkaConsumerService.cs
@@ -25,7 +25,7 @@ public abstract class KafkaConsumerService<T>(ILogger<KafkaConsumerService<T>> l
     /// Minimum nodes you want to run to look for and process messages. Currently, the threads is a static value. Future functionailty might include dynamic scaling.
     /// The default value is 1 if you don't override this property
     /// </summary>
-    public virtual int MinimumNumberOfNodes => 1;
+    public virtual int MinimumNumberOfNodes { get; } = 1;
 
     /// <summary>
     /// Topic to consume from for this service
@@ -40,7 +40,7 @@ public abstract class KafkaConsumerService<T>(ILogger<KafkaConsumerService<T>> l
     /// <summary>
     /// If there are no messages consumed, we will back off for this time period. The default is 15 seconds.
     /// </summary>
-    public virtual TimeSpan NoMessageBackOffPeriod => TimeSpan.FromSeconds(15);
+    public virtual TimeSpan NoMessageBackOffPeriod { get; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Which offset to use. Earliest is the default value

--- a/Src/LibraryCore.Kafka/LibraryCore.Kafka.csproj
+++ b/Src/LibraryCore.Kafka/LibraryCore.Kafka.csproj
@@ -7,7 +7,7 @@
 		<Description>.NetCore Kafka Logic With Consumer Patterns</Description>
 		<RepositoryUrl>https://github.com/dibiancoj/LibraryCore</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>10.0.0</Version>
+		<Version>10.1.0</Version>
 		<Title>LibraryCore - Kafka</Title>
 		<IsTrimmable>true</IsTrimmable>
 		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>


### PR DESCRIPTION
kafka consumer: don't use an arrow function on the hosted service. Even though its a struct 